### PR TITLE
build: make package public

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "prepare": "husky"
   },
   "repository": "https://github.com/elastic/esql-js.git",
-  "private": true,
   "license": "Elastic-2.0",
   "sideEffects": false,
   "devDependencies": {
@@ -78,5 +77,9 @@
     "*.{json,yml,yaml}": [
       "prettier --write"
     ]
+  },
+  "private": false,
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,32 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-export type {
-  ESQLAst,
-  ESQLAstItem,
-  ESQLAstCommand,
-  ESQLAstJoinCommand,
-  ESQLCommand,
-  ESQLCommandOption,
-  ESQLFunction,
-  ESQLTimeSpanLiteral,
-  ESQLLocation,
-  ESQLMessage,
-  ESQLSingleAstItem,
-  ESQLAstQueryExpression,
-  ESQLSource,
-  ESQLColumn,
-  ESQLLiteral,
-  ESQLParamLiteral,
-  EditorError,
-  ESQLAstNode,
-  ESQLInlineCast,
-  ESQLAstBaseItem,
-  ESQLAstChangePointCommand,
-  ESQLAstForkCommand,
-  ESQLForkParens,
-  ESQLAstPromqlCommand,
-} from './types';
+export type * from './types';
 
 export * from './parser';
 export * from './ast';


### PR DESCRIPTION
## Summary
Makes package public.

## Details
Sets the package as public.
Re-exports all types in `/type.ts` to avoid deep imports in Kibana while using it.
