### PR TITLE
build: change licence name

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepare": "husky"
   },
   "repository": "https://github.com/elastic/esql-js.git",
-  "license": "Elastic-2.0",
+  "license": "Elastic License 2.0",
   "sideEffects": false,
   "devDependencies": {
     "@babel/eslint-parser": "7.28.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "prepare": "husky"
   },
   "repository": "https://github.com/elastic/esql-js.git",
-  "private": true,
   "license": "Elastic-2.0",
   "sideEffects": false,
   "devDependencies": {
@@ -78,5 +77,9 @@
     "*.{json,yml,yaml}": [
       "prettier --write"
     ]
+  },
+  "private": false,
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,32 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-export type {
-  ESQLAst,
-  ESQLAstItem,
-  ESQLAstCommand,
-  ESQLAstJoinCommand,
-  ESQLCommand,
-  ESQLCommandOption,
-  ESQLFunction,
-  ESQLTimeSpanLiteral,
-  ESQLLocation,
-  ESQLMessage,
-  ESQLSingleAstItem,
-  ESQLAstQueryExpression,
-  ESQLSource,
-  ESQLColumn,
-  ESQLLiteral,
-  ESQLParamLiteral,
-  EditorError,
-  ESQLAstNode,
-  ESQLInlineCast,
-  ESQLAstBaseItem,
-  ESQLAstChangePointCommand,
-  ESQLAstForkCommand,
-  ESQLForkParens,
-  ESQLAstPromqlCommand,
-} from './types';
+export type * from './types';
 
 export * from './parser';
 export * from './ast';


### PR DESCRIPTION
## Summary
Use the full name of the licence instead of the shorthand, as Kibana has an [ allow list](https://github.com/elastic/kibana/blob/main/src/dev/license_checker/config.ts#L14) where only the full name is listed.

This is done to avoid this error in Kibana CI 
<img width="1501" height="205" alt="image" src="https://github.com/user-attachments/assets/603976a6-e147-45aa-a2e0-26a63a2d4373" />

