### PR TITLE
build: Add backport GH action

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,7 @@
+{
+  "upstream": "elastic/esql-js",
+  "branches": [],
+  "all": true,
+  "prTitle": "{commitMessages} [{targetBranch}]",
+  "labels": ["backport"]
+}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,29 @@
+name: Backport
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport
+    if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'backport:')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Backport
+        uses: sorenlouv/backport-github-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: 'backport:'


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/250514
## Summary
This PR configure the backporting strategy for the repository.

## Details
Adds a github action for automatically backporting using labels.
Adds backport config.
Adds instruction in CONTRIBUTING.md about backporting.

### As a summary, this will be the workflow:
Assuming the current published versions are:
- 1.4.0 <- version with a bug
- 2.0.0 <- current main

1. Create a new branch called `1.x` from `1.4.0` tag.
2. Create a label called `backport:1.x`
3. Add the label to the PR with the fix, ideally before merging, but will also work after merging it.
4. After merging the PR the GH action will create the PR into `1.x` with the fix.
5. Make a release from the `1.x` branch.