### PR TITLE
feat: Generic pretty-printer implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@elastic/esql",
   "version": "0.0.1",
   "author": "Kibana ES|QL team",
-  "description": "A set of ts tools to parse, build and transform ES|QL queries programatically.",
+  "description": "A set of ts tools to parse, build and transform ES|QL queries programmatically.",
   "packageManager": "yarn@1.22.22",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/printer/README.md
+++ b/src/printer/README.md
@@ -1,0 +1,159 @@
+# Printer — Wadler-Lindig Pretty-Printer
+
+A pretty-printing library based on the Wadler-Lindig document algebra
+(Philip Wadler, *"A prettier printer"*, 2003; Christian Lindig's strict
+formulation). The implementation draws heavily from Prettier's internal
+`doc-printer`.
+
+## How it works
+
+Pretty-printing is a two-phase process:
+
+1. **Build** a *document tree* (`Doc`) using combinators (see below). The tree
+   describes the *structure* of possible layouts — it contains no concrete line
+   breaks or indentation yet.
+2. **Layout** the tree into a concrete string. The layout engine fits as much
+   content on each line as possible (up to `printWidth`), breaking `group`
+   nodes when the flat representation would exceed the available width.
+
+Example:
+
+```ts
+import { text, group, indent, line, softline, join, layout } from './printer';
+
+const doc = group([
+  text('SELECT'),
+  indent([line, join(
+    [text(','), line],
+    [text('a'), text('b'), text('c')])]
+  ),
+  line,
+  text('FROM t'),
+]);
+
+layout(doc, { printWidth: 40 });
+// SELECT
+//   a,
+//   b,
+//   c
+// FROM t
+
+layout(doc, { printWidth: 80 });
+// SELECT a, b, c FROM t
+```
+
+## `layout(tree, opts?)`
+
+The main entry point. Takes a *print tree* and returns the formatted string.
+
+Options:
+
+| Option       | Type                                   | Default | Description                              |
+|--------------|----------------------------------------|---------|------------------------------------------|
+| `printWidth` | `number`                               | `80`    | Target maximum line width.               |
+| `tabWidth`   | `number`                               | `2`     | Spaces per indentation level.            |
+| `useTabs`    | `boolean`                              | `false` | Indent with tabs instead of spaces.      |
+| `endOfLine`  | `'\n'` \| `'\r\n'` \| `'\r'` | `'\n'`  | Line-ending character(s).                          |
+
+
+## Combinators / Commands
+
+The printer provides a set of combinators (or "commands") for building print
+trees. These are the building blocks for describing the structure of the output.
+
+### Primitives
+
+- `text(string)` &mdash; Literal text, printed as-is. Must **not** contain
+  newline characters.
+- `Doc[]` (array) &mdash; Concatenation. An array of docs is rendered left to
+  right.
+
+### Line breaks
+
+- `line` &mdash; Space `" "` in flat mode; *newline + indent* in break mode.
+- `softline` &mdash; Nothing `""` in flat mode; *newline + indent* in break mode.
+- `hardline` &mdash; Always a *newline + indent*. Forces the enclosing group to
+  break.
+- `hardlineWithoutBreakParent` &mdash; Like `hardline` but does **not** force
+  the parent group to break.
+- `literalline` &mdash; Hard line break that indents to the *root* position
+  (set by `markAsRoot`) instead of the current nesting level. Preserves
+  trailing whitespace. Forces enclosing groups to break.
+- `literallineWithoutBreakParent` &mdash; Like `literalline` but does **not**
+  force the parent group to break.
+
+### Grouping
+
+- `group(tree, opts?)` &mdash; The core break-decision unit. Tries to render
+  print tree node flat (single line). If it exceeds the remaining width, switches
+  to break mode. Options: `shouldBreak` (force break), `id` (symbol for
+  cross-referencing with `ifBreak`/`indentIfBreak`).
+- `conditionalGroup(states, opts?)` &mdash; Multi-state group. Provide
+  alternative layouts from most compact to most expanded. The engine tries each
+  in order and uses the first one that fits; if none fits, the last state is
+  rendered in break mode.
+- `fill(parts)` &mdash; Wrapping layout. `parts` alternate between content and
+  line-break docs: `[item, line, item, line, ...]`. Fills each line with as
+  many items as fit before breaking — unlike `group`, which is all-or-nothing.
+
+### Indentation
+
+- `indent(tree)` &mdash; Increase indentation by one tab level.
+- `align(n, tree)` &mdash; Increase indentation by exactly `n` spaces (not a
+  tab level). Special values: `-1` (dedent one level),
+  `Number.NEGATIVE_INFINITY` (reset to root), `{ type: 'root' }` (mark current
+  indent as root).
+- `dedent(tree)` &mdash; Decrease indentation by one level. Shorthand for
+  `align(-1, tree)`.
+- `dedentToRoot(tree)` &mdash; Reset indentation to root (column 0 or the
+  position set by `markAsRoot`).
+- `markAsRoot(tree)` &mdash; Mark the current indentation as the "root"
+  position for `literalline`.
+
+### Conditional content
+
+- `ifBreak(breakDoc, flatDoc?, opts?)` &mdash; Emit `breakDoc` when the
+  enclosing group (or a group referenced by `groupId`) is in break mode;
+  otherwise emit `flatDoc`.
+- `indentIfBreak(tree, opts)` &mdash; Conditionally indent `doc` based on a
+  referenced group's mode. Optimized form of
+  `ifBreak(indent(tree), doc, { groupId })`. Set `negate: true` to reverse.
+- `breakParent` &mdash; Force all ancestor groups to break. Propagated during
+  a pre-pass (`propagateBreaks`).
+
+### Comments & line suffixes
+
+- `lineSuffix(tree)` &mdash; Buffer `doc` and emit it at the end of the current
+  line, just before the next line break. Used for trailing comments.
+- `lineSuffixBoundary` &mdash; Force-flush any pending `lineSuffix` content.
+  Prevents trailing comments from leaking past syntactic boundaries.
+
+### Miscellaneous
+
+- `label(lbl, tree)` &mdash; Annotate a doc with an opaque label for
+  language-specific heuristic introspection. No effect on layout.
+- `trim` &mdash; Remove all trailing whitespace from the output at the current
+  position.
+- `cursor` &mdash; Placeholder for cursor-position tracking. The layout engine
+  emits a sentinel; callers can locate it to preserve cursor position after
+  formatting.
+- `join(separator, trees)` &mdash; Join an array of docs with `separator`
+  between each pair.
+- `bracketedList(open, close, sep, items)` &mdash; Convenience for a grouped,
+  indented, bracketed list. Flat: `(a, b, c)`. Broken:
+  ```
+  (
+    a,
+    b,
+    c
+  )
+  ```
+- `addAlignmentToDoc(doc, size, tabWidth)` &mdash; Convert an absolute
+  indentation size into nested `indent`/`align` wrappers inside `dedentToRoot`.
+  Used for embedded content needing a specific indentation level.
+
+## Traversal
+
+- `traverse(doc, { onEnter?, onExit? })` &mdash; Generic depth-first traversal
+  of a doc tree using an explicit stack (no recursion). Return `false` from
+  `onEnter` to skip a node's children.

--- a/src/printer/__tests__/builders.test.ts
+++ b/src/printer/__tests__/builders.test.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  text,
+  line,
+  softline,
+  hardline,
+  hardlineWithoutBreakParent,
+  literalline,
+  literallineWithoutBreakParent,
+  breakParent,
+  group,
+  conditionalGroup,
+  indent,
+  indentIfBreak,
+  align,
+  dedent,
+  dedentToRoot,
+  markAsRoot,
+  fill,
+  ifBreak,
+  lineSuffix,
+  lineSuffixBoundary,
+  label,
+  trim,
+  cursor,
+  join,
+  bracketedList,
+  addAlignmentToDoc,
+} from '..';
+
+describe('builders', () => {
+  describe('text', () => {
+    it('returns the string unchanged', () => {
+      expect(text('hello')).toBe('hello');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(text('')).toBe('');
+    });
+  });
+
+  describe('line primitives', () => {
+    it('line is a LineDoc with no flags', () => {
+      expect(line).toEqual({ type: 'line' });
+    });
+
+    it('softline has soft: true', () => {
+      expect(softline).toEqual({ type: 'line', soft: true });
+    });
+
+    it('hardline is [hardlineWithoutBreakParent, breakParent]', () => {
+      expect(hardline).toEqual([{ type: 'line', hard: true }, { type: 'break-parent' }]);
+    });
+
+    it('hardlineWithoutBreakParent is a hard LineDoc', () => {
+      expect(hardlineWithoutBreakParent).toEqual({ type: 'line', hard: true });
+    });
+
+    it('literalline is [literalLineDoc, breakParent]', () => {
+      expect(literalline).toEqual([
+        { type: 'line', hard: true, literal: true },
+        { type: 'break-parent' },
+      ]);
+    });
+
+    it('literallineWithoutBreakParent is a hard+literal LineDoc', () => {
+      expect(literallineWithoutBreakParent).toEqual({
+        type: 'line',
+        hard: true,
+        literal: true,
+      });
+    });
+
+    it('breakParent is a BreakParentDoc', () => {
+      expect(breakParent).toEqual({ type: 'break-parent' });
+    });
+  });
+
+  describe('group', () => {
+    it('creates a GroupDoc with contents', () => {
+      const doc = group(text('hello'));
+      expect(doc).toEqual({ type: 'group', contents: 'hello' });
+    });
+
+    it('passes shouldBreak option', () => {
+      const doc = group(text('x'), { shouldBreak: true });
+      expect(doc).toEqual({ type: 'group', contents: 'x', shouldBreak: true });
+    });
+
+    it('passes id option', () => {
+      const id = Symbol('test');
+      const doc = group(text('x'), { id });
+      expect(doc).toEqual({ type: 'group', contents: 'x', id });
+    });
+  });
+
+  describe('conditionalGroup', () => {
+    it('sets first state as contents and rest as expandedStates', () => {
+      const doc = conditionalGroup([text('flat'), text('wrapped'), text('broken')]);
+      expect(doc).toEqual({
+        type: 'group',
+        contents: 'flat',
+        expandedStates: ['wrapped', 'broken'],
+      });
+    });
+
+    it('passes id option', () => {
+      const id = Symbol('cg');
+      const doc = conditionalGroup([text('a'), text('b')], { id });
+      expect(doc.id).toBe(id);
+    });
+  });
+
+  describe('indent', () => {
+    it('creates an IndentDoc', () => {
+      const doc = indent(text('hello'));
+      expect(doc).toEqual({ type: 'indent', contents: 'hello' });
+    });
+  });
+
+  describe('align', () => {
+    it('creates an AlignDoc with positive n', () => {
+      const doc = align(4, text('hello'));
+      expect(doc).toEqual({ type: 'align', n: 4, contents: 'hello' });
+    });
+
+    it('accepts { type: "root" } for markAsRoot', () => {
+      const doc = align({ type: 'root' }, text('x'));
+      expect(doc).toEqual({ type: 'align', n: { type: 'root' }, contents: 'x' });
+    });
+  });
+
+  describe('dedent / dedentToRoot / markAsRoot', () => {
+    it('dedent wraps align(-1)', () => {
+      const doc = dedent(text('hello'));
+      expect(doc).toEqual({ type: 'align', n: -1, contents: 'hello' });
+    });
+
+    it('dedentToRoot wraps align(-Infinity)', () => {
+      const doc = dedentToRoot(text('hello'));
+      expect(doc).toEqual({
+        type: 'align',
+        n: Number.NEGATIVE_INFINITY,
+        contents: 'hello',
+      });
+    });
+
+    it('markAsRoot wraps align({ type: "root" })', () => {
+      const doc = markAsRoot(text('hello'));
+      expect(doc).toEqual({
+        type: 'align',
+        n: { type: 'root' },
+        contents: 'hello',
+      });
+    });
+  });
+
+  describe('fill', () => {
+    it('creates a FillDoc', () => {
+      const doc = fill([text('a'), line, text('b')]);
+      expect(doc).toEqual({
+        type: 'fill',
+        parts: ['a', { type: 'line' }, 'b'],
+      });
+    });
+  });
+
+  describe('ifBreak', () => {
+    it('creates an IfBreakDoc with default flatContents', () => {
+      const doc = ifBreak(text('broken'));
+      expect(doc).toEqual({
+        type: 'if-break',
+        breakContents: 'broken',
+        flatContents: '',
+      });
+    });
+
+    it('accepts explicit flatContents', () => {
+      const doc = ifBreak(text('broken'), text('flat'));
+      expect(doc).toEqual({
+        type: 'if-break',
+        breakContents: 'broken',
+        flatContents: 'flat',
+      });
+    });
+
+    it('passes groupId', () => {
+      const gid = Symbol('g');
+      const doc = ifBreak(text('b'), text('f'), { groupId: gid });
+      expect(doc.groupId).toBe(gid);
+    });
+  });
+
+  describe('indentIfBreak', () => {
+    it('creates an IndentIfBreakDoc', () => {
+      const gid = Symbol('g');
+      const doc = indentIfBreak(text('x'), { groupId: gid });
+      expect(doc).toEqual({
+        type: 'indent-if-break',
+        contents: 'x',
+        groupId: gid,
+      });
+    });
+
+    it('passes negate option', () => {
+      const gid = Symbol('g');
+      const doc = indentIfBreak(text('x'), { groupId: gid, negate: true });
+      expect(doc.negate).toBe(true);
+    });
+  });
+
+  describe('lineSuffix', () => {
+    it('creates a LineSuffixDoc', () => {
+      const doc = lineSuffix(text(' // comment'));
+      expect(doc).toEqual({ type: 'line-suffix', contents: ' // comment' });
+    });
+  });
+
+  describe('lineSuffixBoundary', () => {
+    it('is a LineSuffixBoundaryDoc', () => {
+      expect(lineSuffixBoundary).toEqual({ type: 'line-suffix-boundary' });
+    });
+  });
+
+  describe('label', () => {
+    it('wraps contents with a label', () => {
+      const doc = label('test', text('x'));
+      expect(doc).toEqual({ type: 'label', label: 'test', contents: 'x' });
+    });
+
+    it('returns contents unwrapped if label is falsy', () => {
+      expect(label(null, text('x'))).toBe('x');
+      expect(label(undefined, text('x'))).toBe('x');
+      expect(label('', text('x'))).toBe('x');
+      expect(label(0, text('x'))).toBe('x');
+    });
+  });
+
+  describe('trim', () => {
+    it('is a TrimDoc', () => {
+      expect(trim).toEqual({ type: 'trim' });
+    });
+  });
+
+  describe('cursor', () => {
+    it('is a CursorDoc', () => {
+      expect(cursor).toEqual({ type: 'cursor' });
+    });
+  });
+
+  describe('join', () => {
+    it('interleaves separator between docs', () => {
+      const doc = join(text(', '), [text('a'), text('b'), text('c')]);
+      expect(doc).toEqual(['a', ', ', 'b', ', ', 'c']);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(join(text(', '), [])).toEqual([]);
+    });
+
+    it('returns single item without separator', () => {
+      expect(join(text(', '), [text('a')])).toEqual(['a']);
+    });
+  });
+
+  describe('bracketedList', () => {
+    it('returns [open, close] for empty items', () => {
+      expect(bracketedList('(', ')', ',', [])).toEqual(['(', ')']);
+    });
+
+    it('creates a group with indent and softlines', () => {
+      const doc = bracketedList('(', ')', ',', [text('a'), text('b')]);
+      expect(doc).toEqual(
+        group(['(', indent([softline, join([',', line], ['a', 'b'])]), softline, ')'])
+      );
+    });
+  });
+
+  describe('addAlignmentToDoc', () => {
+    it('returns doc unchanged when size is 0', () => {
+      const doc = text('x');
+      expect(addAlignmentToDoc(doc, 0, 2)).toBe('x');
+    });
+
+    it('wraps with indent for tab-sized chunks', () => {
+      const doc = addAlignmentToDoc(text('x'), 4, 2);
+      expect(doc).toEqual(dedentToRoot(indent(indent(text('x')))));
+    });
+
+    it('uses align for remainder', () => {
+      const doc = addAlignmentToDoc(text('x'), 5, 2);
+      expect(doc).toEqual(dedentToRoot(align(1, indent(indent(text('x'))))));
+    });
+  });
+});

--- a/src/printer/__tests__/layout.conditional_group.test.ts
+++ b/src/printer/__tests__/layout.conditional_group.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { text, softline, hardline, group, indent, conditionalGroup, join, layout } from '..';
+
+describe('conditionalGroup', () => {
+  it('uses first state (flat) when it fits', () => {
+    const items = [text('alpha'), text('beta'), text('gamma')];
+
+    const doc = conditionalGroup([
+      // Phase 1: flat with spaces — "alpha, beta, gamma"
+      group(join(text(', '), items)),
+      // Phase 2: compact — "alpha,beta,gamma"
+      group(join([text(','), softline], items)),
+      // Phase 3: one per line
+      group([indent([hardline, join([text(','), hardline], items)]), hardline], {
+        shouldBreak: true,
+      }),
+    ]);
+
+    expect(layout(doc, { printWidth: 20 })).toBe('alpha, beta, gamma');
+    expect(layout(doc, { printWidth: 17 })).toBe('alpha,beta,gamma');
+    expect(layout(doc, { printWidth: 10 })).toBe('\n  alpha,\n  beta,\n  gamma\n');
+  });
+
+  it('three-phase list with brackets', () => {
+    const items = [text('alpha'), text('beta'), text('gamma'), text('delta')];
+    const sep = text(',');
+
+    const doc = conditionalGroup([
+      // Phase 1: all on one line — "(alpha, beta, gamma, delta)" = 27
+      group([text('('), join([sep, text(' ')], items), text(')')]),
+      // Phase 2: compact (no spaces) — "(alpha,beta,gamma,delta)" = 24
+      group([text('('), join([sep, softline], items), text(')')]),
+      // Phase 3: one per line
+      group([text('('), indent([hardline, join([sep, hardline], items)]), hardline, text(')')], {
+        shouldBreak: true,
+      }),
+    ]);
+
+    expect(layout(doc, { printWidth: 30 })).toBe('(alpha, beta, gamma, delta)');
+    expect(layout(doc, { printWidth: 25 })).toBe('(alpha,beta,gamma,delta)');
+    expect(layout(doc, { printWidth: 10 })).toBe('(\n  alpha,\n  beta,\n  gamma,\n  delta\n)');
+  });
+
+  it('with two states only', () => {
+    const doc = conditionalGroup([
+      // Try flat
+      join([text(', ')], [text('aaa'), text('bbb'), text('ccc')]),
+      // Fallback: broken
+      group(
+        [indent([hardline, join([text(','), hardline], [text('aaa'), text('bbb'), text('ccc')])])],
+        { shouldBreak: true }
+      ),
+    ]);
+
+    expect(layout(doc, { printWidth: 20 })).toBe('aaa, bbb, ccc');
+    expect(layout(doc, { printWidth: 10 })).toBe('\n  aaa,\n  bbb,\n  ccc');
+  });
+});

--- a/src/printer/__tests__/layout.fill.test.ts
+++ b/src/printer/__tests__/layout.fill.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { text, line, softline, fill, join, layout } from '..';
+
+describe('fill (wrapping layout)', () => {
+  it('renders all items on one line when they fit', () => {
+    const items = ['one', 'two', 'three'].map(text);
+    const doc = fill(join(line, items));
+
+    expect(layout(doc, { printWidth: 80 })).toBe('one two three');
+  });
+
+  it('wraps items across lines', () => {
+    const items = ['aaa', 'bbb', 'ccc', 'ddd', 'eee'].map(text);
+    const doc = fill(join(line, items));
+
+    expect(layout(doc, { printWidth: 12 })).toBe('aaa bbb ccc\nddd eee');
+  });
+
+  it('wraps with softline (no spaces)', () => {
+    const items = ['aaa', 'bbb', 'ccc', 'ddd'].map(text);
+    const doc = fill(join(softline, items));
+
+    expect(layout(doc, { printWidth: 10 })).toBe('aaabbbccc\nddd');
+  });
+
+  it('handles single item', () => {
+    const doc = fill([text('hello')]);
+
+    expect(layout(doc, { printWidth: 80 })).toBe('hello');
+  });
+
+  it('handles two items', () => {
+    const doc = fill([text('hello'), line, text('world')]);
+
+    expect(layout(doc, { printWidth: 80 })).toBe('hello world');
+    expect(layout(doc, { printWidth: 5 })).toBe('hello\nworld');
+  });
+
+  it('handles empty parts', () => {
+    const doc = fill([]);
+
+    expect(layout(doc, { printWidth: 80 })).toBe('');
+  });
+
+  it('wraps words example', () => {
+    const words = 'the quick brown fox jumps over the lazy dog'.split(' ').map(text);
+    const doc = fill(join(line, words));
+
+    expect(layout(doc, { printWidth: 20 })).toBe('the quick brown fox\njumps over the lazy\ndog');
+  });
+
+  it('fill with width 15', () => {
+    const items = ['one', 'two', 'three', 'four', 'five'].map(text);
+    const doc = fill(join(line, items));
+
+    expect(layout(doc, { printWidth: 15 })).toBe('one two three\nfour five');
+  });
+
+  it('fill with width 10', () => {
+    const items = ['one', 'two', 'three', 'four', 'five'].map(text);
+    const doc = fill(join(line, items));
+
+    expect(layout(doc, { printWidth: 10 })).toBe('one two\nthree four\nfive');
+  });
+});

--- a/src/printer/__tests__/layout.line_suffix.test.ts
+++ b/src/printer/__tests__/layout.line_suffix.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { text, hardline, group, lineSuffix, lineSuffixBoundary, layout } from '..';
+
+describe('lineSuffix', () => {
+  it('places comment at end of line', () => {
+    const doc = [text('x'), lineSuffix(text(' # comment')), text(';'), hardline, text('y')];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('x; # comment\ny');
+  });
+
+  it('buffers multiple suffixes', () => {
+    const doc = [
+      text('a'),
+      lineSuffix(text(' // c1')),
+      text('b'),
+      lineSuffix(text(' // c2')),
+      hardline,
+      text('next'),
+    ];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('ab // c1 // c2\nnext');
+  });
+
+  it('flushes suffix at end of document', () => {
+    const doc = [text('code'), lineSuffix(text(' // trailing'))];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('code // trailing');
+  });
+
+  it('suffix ordering with trailing punctuation', () => {
+    const doc = [text('field'), lineSuffix(text(' // comment')), text(','), hardline, text('next')];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('field, // comment\nnext');
+  });
+});
+
+describe('lineSuffixBoundary', () => {
+  it('flushes pending suffix before boundary', () => {
+    const doc = group([text('{'), lineSuffix(text(' # c')), lineSuffixBoundary, text('}')]);
+
+    expect(layout(doc, { printWidth: 80 })).toBe('{ # c\n}');
+  });
+
+  it('does nothing when no suffix is pending', () => {
+    const doc = [text('a'), lineSuffixBoundary, text('b')];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('ab');
+  });
+});
+
+describe('inline block comments (text-based)', () => {
+  it('left and right inline comments are plain text', () => {
+    const doc = [text('/* left */'), text(' '), text('node'), text(' '), text('/* right */')];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('/* left */ node /* right */');
+  });
+});
+
+describe('own-line comments', () => {
+  it('top comment above node', () => {
+    const doc = [text('// top comment'), hardline, text('node')];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('// top comment\nnode');
+  });
+
+  it('bottom comment below node', () => {
+    const doc = [text('node'), hardline, text('// bottom comment')];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('node\n// bottom comment');
+  });
+
+  it('full 5-slot comment model', () => {
+    const nodeDoc = group([text('('), text('value'), text(')')]);
+
+    const doc = [
+      text('// top comment'),
+      hardline,
+      text('/* left */ '),
+      nodeDoc,
+      text(' /* right */'),
+      lineSuffix(text(' // trailing')),
+      hardline,
+      text('// bottom comment'),
+    ];
+
+    expect(layout(doc, { printWidth: 80 })).toBe(
+      '// top comment\n/* left */ (value) /* right */ // trailing\n// bottom comment'
+    );
+  });
+});

--- a/src/printer/__tests__/layout.scenarios.test.ts
+++ b/src/printer/__tests__/layout.scenarios.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { text, line, softline, hardline, group, indent, join, fill, layout } from '..';
+
+describe('layout scenarios', () => {
+  it('formats a simple function call that fits on one line', () => {
+    const doc = group([
+      text('main('),
+      indent([softline, text('"hello world"')]),
+      softline,
+      text(')'),
+    ]);
+
+    expect(layout(doc, { printWidth: 40 })).toBe(`main("hello world")`);
+
+    const doc2 = group([
+      text('main('),
+      indent([softline, text('"hello world"')]),
+      softline,
+      text(')'),
+    ]);
+
+    expect(layout(doc2, { printWidth: 10 })).toBe(`main(\n  "hello world"\n)`);
+  });
+
+  it('breaks a function body across lines when it exceeds printWidth', () => {
+    const body = [text('console.log("hello");'), hardline, text('return 0;')];
+    const doc = group([
+      text('function main() {'),
+      indent([hardline, ...body]),
+      hardline,
+      text('}'),
+    ]);
+
+    expect('\n' + layout(doc, { printWidth: 80 })).toBe(`
+function main() {
+  console.log("hello");
+  return 0;
+}`);
+  });
+
+  it('wraps a long argument list with indent when it does not fit', () => {
+    const args = [text('alpha'), text('beta'), text('gamma'), text('delta'), text('epsilon')];
+
+    const doc = group([
+      text('render('),
+      indent([softline, join([text(','), line], args)]),
+      softline,
+      text(')'),
+    ]);
+
+    expect(layout(doc, { printWidth: 30 })).toBe(
+      ['render(', '  alpha,', '  beta,', '  gamma,', '  delta,', '  epsilon', ')'].join('\n')
+    );
+  });
+
+  it('fill wraps words to fill each line', () => {
+    const words = ['The', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy', 'dog'];
+    const parts = join(
+      line,
+      words.map((w) => text(w))
+    );
+
+    const doc = fill(parts);
+
+    expect(layout(doc, { printWidth: 20 })).toBe(`The quick brown fox\njumps over the lazy\ndog`);
+  });
+});

--- a/src/printer/__tests__/layout.test.ts
+++ b/src/printer/__tests__/layout.test.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  text,
+  line,
+  softline,
+  hardline,
+  group,
+  indent,
+  align,
+  ifBreak,
+  indentIfBreak,
+  join,
+  bracketedList,
+  trim,
+  layout,
+} from '..';
+
+describe('layout()', () => {
+  it('hardline forces parent group to break', () => {
+    const doc = group([text('a'), hardline, text('b')]);
+
+    expect(layout(doc, { printWidth: 80 })).toBe('a\nb');
+  });
+
+  it('hardline propagates through nested groups', () => {
+    const inner = group([text('x'), hardline, text('y')]);
+    const outer = group([text('('), line, inner, line, text(')')]);
+
+    expect(layout(outer, { printWidth: 80 })).toBe('(\nx\ny\n)');
+  });
+
+  it('hardline propagates through deeply nested groups', () => {
+    const innermost = group([text('a'), hardline, text('b')]);
+    const middle = group([text('['), line, innermost, line, text(']')]);
+    const outer = group([text('('), line, middle, line, text(')')]);
+
+    expect(layout(outer, { printWidth: 80 })).toBe('(\n[\na\nb\n]\n)');
+  });
+
+  it('does not break sibling groups', () => {
+    const broken = group([text('a'), hardline, text('b')]);
+    const intact = group([text('c'), line, text('d')]);
+    const doc = [broken, text(' | '), intact];
+
+    expect(layout(doc, { printWidth: 80 })).toBe('a\nb | c d');
+  });
+
+  it('handles indent inside group with hardline', () => {
+    const doc = group([text('start'), indent([hardline, text('body')]), hardline, text('end')]);
+
+    expect(layout(doc, { printWidth: 80 })).toBe('start\n  body\nend');
+  });
+
+  describe('string rendering', () => {
+    it('renders a plain string', () => {
+      expect(layout('hello')).toBe('hello');
+    });
+
+    it('renders concatenated strings', () => {
+      expect(layout([text('a'), text('b'), text('c')])).toBe('abc');
+    });
+
+    it('renders empty string for empty doc', () => {
+      expect(layout('')).toBe('');
+    });
+
+    it('renders empty array', () => {
+      expect(layout([])).toBe('');
+    });
+  });
+
+  describe('group', () => {
+    it('renders flat when content fits', () => {
+      const doc = group([text('('), text('hello'), text(')')]);
+      expect(layout(doc, { printWidth: 80 })).toBe('(hello)');
+    });
+
+    it('breaks when content exceeds width', () => {
+      const doc = group([text('('), indent([softline, text('hello')]), softline, text(')')]);
+      expect(layout(doc, { printWidth: 5 })).toBe('(\n  hello\n)');
+    });
+
+    it('respects shouldBreak option', () => {
+      const doc = group([text('a'), line, text('b')], { shouldBreak: true });
+      expect(layout(doc, { printWidth: 80 })).toBe('a\nb');
+    });
+
+    it('nested groups break outermost first', () => {
+      const inner = group([text('['), indent([softline, text('x')]), softline, text(']')]);
+      const outer = group([text('func('), indent([softline, inner]), softline, text(')')]);
+      // At width 8: outer breaks (func([x]) = 9 > 8), inner stays flat ([x] = 3 ≤ 8-2)
+      expect(layout(outer, { printWidth: 8 })).toBe('func(\n  [x]\n)');
+    });
+  });
+
+  describe('indent', () => {
+    it('indents content after line break', () => {
+      const doc = group([text('start'), indent([line, text('indented')])], { shouldBreak: true });
+      expect(layout(doc, { printWidth: 80 })).toBe('start\n  indented');
+    });
+
+    it('uses configured tabWidth', () => {
+      const doc = group([text('x'), indent([line, text('y')])], { shouldBreak: true });
+      expect(layout(doc, { printWidth: 80, tabWidth: 4 })).toBe('x\n    y');
+    });
+
+    it('nests multiple indents', () => {
+      const doc = group([text('a'), indent([line, text('b'), indent([line, text('c')])])], {
+        shouldBreak: true,
+      });
+      expect(layout(doc, { printWidth: 80 })).toBe('a\n  b\n    c');
+    });
+  });
+
+  describe('line variants', () => {
+    it('line renders as space in flat mode', () => {
+      const doc = group([text('a'), line, text('b')]);
+      expect(layout(doc, { printWidth: 80 })).toBe('a b');
+    });
+
+    it('softline renders as nothing in flat mode', () => {
+      const doc = group([text('a'), softline, text('b')]);
+      expect(layout(doc, { printWidth: 80 })).toBe('ab');
+    });
+
+    it('line renders as newline+indent in break mode', () => {
+      const doc = group([text('a'), line, text('b')], { shouldBreak: true });
+      expect(layout(doc, { printWidth: 80 })).toBe('a\nb');
+    });
+
+    it('softline renders as newline+indent in break mode', () => {
+      const doc = group([text('a'), softline, text('b')], { shouldBreak: true });
+      expect(layout(doc, { printWidth: 80 })).toBe('a\nb');
+    });
+
+    it('hardline always renders as newline', () => {
+      const doc = [text('a'), hardline, text('b')];
+      expect(layout(doc, { printWidth: 80 })).toBe('a\nb');
+    });
+  });
+
+  describe('ifBreak', () => {
+    it('uses flatContents when group is flat', () => {
+      const doc = group([text('('), ifBreak(text('BREAK'), text('FLAT')), text(')')]);
+      expect(layout(doc, { printWidth: 80 })).toBe('(FLAT)');
+    });
+
+    it('uses breakContents when group is broken', () => {
+      const doc = group([text('('), ifBreak(text('BREAK'), text('FLAT')), text(')')], {
+        shouldBreak: true,
+      });
+      expect(layout(doc, { printWidth: 80 })).toBe('(BREAK)');
+    });
+
+    it('references another group via groupId', () => {
+      const gid = Symbol('g');
+      const doc = [
+        group(text('x'), { id: gid, shouldBreak: true }),
+        ifBreak(text('YES'), text('NO'), { groupId: gid }),
+      ];
+      expect(layout(doc, { printWidth: 80 })).toBe('xYES');
+    });
+
+    it('trailing comma only when broken', () => {
+      const listId = Symbol('list');
+      const doc = group(
+        [
+          text('('),
+          indent([
+            softline,
+            join([text(','), line], [text('a'), text('b'), text('c')]),
+            ifBreak(text(','), text(''), { groupId: listId }),
+          ]),
+          softline,
+          text(')'),
+        ],
+        { id: listId }
+      );
+
+      expect(layout(doc, { printWidth: 20 })).toBe('(a, b, c)');
+      expect(layout(doc, { printWidth: 5 })).toBe('(\n  a,\n  b,\n  c,\n)');
+    });
+  });
+
+  describe('indentIfBreak', () => {
+    it('applies indent when referenced group breaks', () => {
+      const gid = Symbol('g');
+      const doc = group([text('return'), indentIfBreak([line, text('value')], { groupId: gid })], {
+        id: gid,
+      });
+      expect(layout(doc, { printWidth: 10 })).toBe('return\n  value');
+    });
+
+    it('does not indent when referenced group is flat', () => {
+      const gid = Symbol('g');
+      const doc = group([text('return'), indentIfBreak([line, text('v')], { groupId: gid })], {
+        id: gid,
+      });
+      expect(layout(doc, { printWidth: 80 })).toBe('return v');
+    });
+
+    it('negated: indents when flat, not when broken', () => {
+      const gid = Symbol('g');
+      const doc = group(
+        [text('x'), indentIfBreak([line, text('y')], { groupId: gid, negate: true })],
+        { id: gid }
+      );
+      // When flat (fits at width 80), negate=true means indent IS applied
+      expect(layout(doc, { printWidth: 80 })).toBe('x y');
+    });
+  });
+
+  describe('align', () => {
+    it('aligns by fixed number of spaces', () => {
+      const doc = group([text('fn('), align(3, [text('a,'), line, text('b')])], {
+        shouldBreak: true,
+      });
+      expect(layout(doc, { printWidth: 80 })).toBe('fn(a,\n   b');
+    });
+  });
+
+  describe('trim', () => {
+    it('removes trailing whitespace', () => {
+      const doc = [text('hello   '), trim, text('world')];
+      expect(layout(doc, { printWidth: 80 })).toBe('helloworld');
+    });
+  });
+
+  describe('bracketedList', () => {
+    it('renders flat when it fits', () => {
+      const doc = bracketedList('(', ')', ',', [text('a'), text('b'), text('c')]);
+      expect(layout(doc, { printWidth: 40 })).toBe('(a, b, c)');
+    });
+
+    it('breaks when too wide', () => {
+      const doc = bracketedList('(', ')', ',', [text('alpha'), text('beta'), text('gamma')]);
+      expect(layout(doc, { printWidth: 15 })).toBe('(\n  alpha,\n  beta,\n  gamma\n)');
+    });
+
+    it('renders empty brackets for no items', () => {
+      expect(layout(bracketedList('(', ')', ',', []))).toBe('()');
+    });
+  });
+
+  describe('nested structures', () => {
+    it('nested bracketed lists', () => {
+      const inner = bracketedList('{', '}', ',', [text('a'), text('b')]);
+      const outer = bracketedList('(', ')', ',', [text('fn'), inner, text('c')]);
+
+      expect(layout(outer, { printWidth: 30 })).toBe('(fn, {a, b}, c)');
+    });
+
+    it('binary operator with conditional indentation', () => {
+      const doc = group([text('left_operand'), indent([line, text('+ '), text('right_operand')])]);
+      expect(layout(doc, { printWidth: 40 })).toBe('left_operand + right_operand');
+      expect(layout(doc, { printWidth: 20 })).toBe('left_operand\n  + right_operand');
+    });
+  });
+
+  describe('end-of-line', () => {
+    it('uses \\r\\n when configured', () => {
+      const doc = group([text('a'), line, text('b')], { shouldBreak: true });
+      expect(layout(doc, { printWidth: 80, endOfLine: '\r\n' })).toBe('a\r\nb');
+    });
+  });
+});

--- a/src/printer/__tests__/prepare.test.ts
+++ b/src/printer/__tests__/prepare.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { text, line, hardline } from '../builders';
+import { propagateBreaks } from '../prepare';
+import type { GroupNode } from '../types';
+
+describe('propagateBreaks', () => {
+  it('sets `shouldBreak` on parent groups', () => {
+    const inner: GroupNode = { type: 'group', contents: [text('a'), hardline, text('b')] };
+    const outer: GroupNode = { type: 'group', contents: inner };
+
+    propagateBreaks(outer);
+
+    expect(inner.shouldBreak).toBe(true);
+    expect(outer.shouldBreak).toBe(true);
+  });
+
+  it('does not set `shouldBreak` when there is no hardline', () => {
+    const doc: GroupNode = { type: 'group', contents: [text('a'), line, text('b')] };
+
+    propagateBreaks(doc);
+
+    expect(!!doc.shouldBreak).toBe(false);
+  });
+});

--- a/src/printer/__tests__/traversal.test.ts
+++ b/src/printer/__tests__/traversal.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { text, group, indent, fill, ifBreak, line, hardline } from '../builders';
+import { traverse } from '../traversal';
+import type { Doc } from '../types';
+
+const collect = (doc: Doc) => {
+  const entered: Doc[] = [];
+  const exited: Doc[] = [];
+  traverse(doc, {
+    onEnter: (d) => {
+      entered.push(d);
+    },
+    onExit: (d) => {
+      exited.push(d);
+    },
+  });
+  return { entered, exited };
+};
+
+describe('traverse', () => {
+  it('visits a plain string', () => {
+    const { entered, exited } = collect(text('hello'));
+
+    expect(entered).toEqual(['hello']);
+    expect(exited).toEqual(['hello']);
+  });
+
+  it('visits an array of strings in order', () => {
+    const doc: Doc = [text('a'), text('b'), text('c')];
+    const { entered, exited } = collect(doc);
+
+    expect(entered).toEqual([doc, 'a', 'b', 'c']);
+    expect(exited).toEqual(['a', 'b', 'c', doc]);
+  });
+
+  it('visits group and its contents', () => {
+    const inner = text('x');
+    const doc = group(inner);
+    const { entered, exited } = collect(doc);
+
+    expect(entered).toEqual([doc, 'x']);
+    expect(exited).toEqual(['x', doc]);
+  });
+
+  it('visits nested indent > group > text', () => {
+    const doc = indent(group(text('nested')));
+    const entered: string[] = [];
+
+    traverse(doc, {
+      onEnter: (d) => {
+        if (typeof d !== 'string' && !Array.isArray(d)) {
+          entered.push(d.type);
+        }
+      },
+    });
+
+    expect(entered).toEqual(['indent', 'group']);
+  });
+
+  it('visits fill parts left-to-right', () => {
+    const doc = fill([text('a'), line, text('b')]);
+    const entered: Doc[] = [];
+
+    traverse(doc, {
+      onEnter: (d) => {
+        entered.push(d);
+      },
+    });
+
+    expect(entered[0]).toBe(doc);
+    expect(entered[1]).toBe('a');
+    expect(entered[2]).toBe(line);
+    expect(entered[3]).toBe('b');
+  });
+
+  it('visits both branches of ifBreak', () => {
+    const doc = ifBreak(text('broken'), text('flat'));
+    const strings: string[] = [];
+
+    traverse(doc, {
+      onEnter: (d) => {
+        if (typeof d === 'string') strings.push(d);
+      },
+    });
+
+    expect(strings).toContain('broken');
+    expect(strings).toContain('flat');
+  });
+
+  it('skips children when onEnter returns false', () => {
+    const doc = group([text('a'), indent(text('b'))]);
+    const entered: Doc[] = [];
+
+    traverse(doc, {
+      onEnter: (d) => {
+        entered.push(d);
+        // Skip the inner array's children
+        if (Array.isArray(d)) return false;
+      },
+    });
+
+    // group entered, then the array, but array children are skipped
+    expect(entered).toHaveLength(2);
+    expect(entered[0]).toBe(doc);
+  });
+
+  it('works without onExit callback', () => {
+    const entered: Doc[] = [];
+
+    traverse(hardline, {
+      onEnter: (d) => {
+        entered.push(d);
+      },
+    });
+
+    // hardline is [LineNode, BreakParentNode]
+    expect(entered).toHaveLength(3);
+  });
+
+  it('works without onEnter callback', () => {
+    const exited: Doc[] = [];
+
+    traverse(group(text('z')), {
+      onExit: (d) => {
+        exited.push(d);
+      },
+    });
+
+    expect(exited[0]).toBe('z');
+  });
+});

--- a/src/printer/builders.ts
+++ b/src/printer/builders.ts
@@ -1,0 +1,313 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  Doc,
+  GroupNode,
+  FillNode,
+  IndentNode,
+  IndentIfBreakNode,
+  AlignNode,
+  IfBreakNode,
+  LineNode,
+  LineSuffixNode,
+  LineSuffixBoundaryNode,
+  BreakParentNode,
+  LabelNode,
+  TrimNode,
+  CursorNode,
+} from './types';
+
+/**
+ * Literal text. Must not contain newline characters.
+ */
+export const text = (s: string): string => s;
+
+/**
+ * Space if flat, newline + indent if broken.
+ */
+export const line: LineNode = { type: 'line' };
+
+/**
+ * Nothing if flat, newline + indent if broken.
+ */
+export const softline: LineNode = { type: 'line', soft: true };
+
+/**
+ * Always a newline + indent. Forces enclosing group to break.
+ */
+export const hardline: Doc = [{ type: 'line', hard: true }, { type: 'break-parent' }];
+
+/**
+ * Like `hardline` but does NOT force parent group to break.
+ */
+export const hardlineWithoutBreakParent: LineNode = { type: 'line', hard: true };
+
+/**
+ * A hard line break that indents to the root position (set by `markAsRoot`)
+ * rather than the current nesting level. Also preserves trailing whitespace
+ * on the preceding line (no trim). Used for embedded/template content.
+ *
+ * Like `hardline`, forces enclosing groups to break.
+ */
+export const literalline: Doc = [
+  { type: 'line', hard: true, literal: true },
+  { type: 'break-parent' },
+];
+
+/**
+ * Like `literalline` but does NOT force parent group to break.
+ */
+export const literallineWithoutBreakParent: LineNode = {
+  type: 'line',
+  hard: true,
+  literal: true,
+};
+
+/**
+ * Force all parent groups to break.
+ */
+export const breakParent: BreakParentNode = { type: 'break-parent' };
+
+/**
+ * Try to print `contents` on a single line (flat mode).
+ * If it doesn't fit within the remaining width, print in broken mode
+ * (all "line" nodes inside become newlines).
+ *
+ * @param contents - The document to group.
+ * @param opts.shouldBreak - Force this group to break (skip flat attempt).
+ * @param opts.id - Symbol ID for cross-referencing with `ifBreak`.
+ */
+export const group = (contents: Doc, opts?: { shouldBreak?: boolean; id?: symbol }): GroupNode => ({
+  type: 'group',
+  contents,
+  shouldBreak: opts?.shouldBreak,
+  id: opts?.id,
+});
+
+/**
+ * Provide multiple alternative layout representations, from most compact
+ * to most expanded. The layout engine tries each in order and uses the
+ * first one that fits. If none fits, the last state is used in break mode.
+ *
+ * Primary use case: three-phase list formatting:
+ *
+ * ```ts
+ * conditionalGroup([flatLayout, wrappedLayout, brokenLayout])
+ * ```
+ */
+export const conditionalGroup = (states: Doc[], opts?: { id?: symbol }): GroupNode => ({
+  type: 'group',
+  contents: states[0],
+  expandedStates: states.slice(1),
+  id: opts?.id,
+});
+
+/**
+ * Increase indentation by one tab level for `contents`.
+ */
+export const indent = (contents: Doc): IndentNode => ({
+  type: 'indent',
+  contents,
+});
+
+/**
+ * Increase indentation by exactly `n` spaces (not a tab level).
+ *
+ * Special values:
+ *
+ * - Positive integer: add `n` spaces of alignment.
+ * - `-1`: dedent by one level (see `dedent()`).
+ * - `Number.NEGATIVE_INFINITY`: reset to root (see `dedentToRoot()`).
+ * - `{ type: 'root' }`: mark current indent as root (see `markAsRoot()`).
+ */
+export const align = (n: number | { type: 'root' }, contents: Doc): AlignNode => ({
+  type: 'align',
+  n,
+  contents,
+});
+
+/**
+ * Decrease indentation by one level.
+ */
+export const dedent = (contents: Doc): AlignNode => align(-1, contents);
+
+/**
+ * Reset indentation to the root level (column 0, or the position set by
+ * `markAsRoot`). Equivalent to `align(Number.NEGATIVE_INFINITY, contents)`.
+ */
+export const dedentToRoot = (contents: Doc): AlignNode => align(Number.NEGATIVE_INFINITY, contents);
+
+/**
+ * Mark the current indentation as the "root" position. Content inside
+ * `markAsRoot` that uses `literalline` will indent to this position
+ * rather than column 0. Used for embedded/template content.
+ */
+export const markAsRoot = (contents: Doc): AlignNode => align({ type: 'root' }, contents);
+
+/**
+ * Wrapping layout. `parts` should alternate content and line-break docs:
+ *
+ * ```ts
+ * fill([item1, line, item2, line, item3])
+ * ```
+ *
+ * The engine fills each line with as many items as fit before breaking.
+ */
+export const fill = (parts: Doc[]): FillNode => ({
+  type: 'fill',
+  parts,
+});
+
+/**
+ * Print `breakContents` if the enclosing group (or the group identified
+ * by `groupId`) is in broken mode; otherwise print `flatContents`.
+ */
+export const ifBreak = (
+  breakContents: Doc,
+  flatContents?: Doc,
+  opts?: { groupId?: symbol }
+): IfBreakNode => ({
+  type: 'if-break',
+  breakContents,
+  flatContents: flatContents ?? '',
+  groupId: opts?.groupId,
+});
+
+/**
+ * Conditionally indent based on a referenced group's mode. Optimized form
+ * of `ifBreak(indent(doc), doc, { groupId })`.
+ *
+ * When the referenced group is broken, contents are indented. When the
+ * referenced group is flat, contents are not indented. Set `negate: true`
+ * to reverse this behavior.
+ */
+export const indentIfBreak = (
+  contents: Doc,
+  opts: { groupId: symbol; negate?: boolean }
+): IndentIfBreakNode => ({
+  type: 'indent-if-break',
+  contents,
+  groupId: opts.groupId,
+  negate: opts.negate,
+});
+
+/**
+ * Buffer `contents` and emit at the end of the current line. Used for trailing
+ * comments: the comment text is deferred until just before the next newline.
+ *
+ * ```ts
+ * [text("stmt"), lineSuffix(" # comment"), text(";"), hardline]
+ * // stmt; # comment\n
+ * ```
+ */
+export const lineSuffix = (contents: Doc): LineSuffixNode => ({
+  type: 'line-suffix',
+  contents,
+});
+
+/**
+ * Force-flush any pending lineSuffix. Prevents comment leakage across
+ * syntactic boundaries.
+ */
+export const lineSuffixBoundary: LineSuffixBoundaryNode = { type: 'line-suffix-boundary' };
+
+/**
+ * Annotate a doc with a label. No effect on layout. Returns `contents`
+ * unwrapped if `label` is falsy.
+ */
+export const label = (lbl: unknown, contents: Doc): Doc =>
+  lbl ? ({ type: 'label', label: lbl, contents } as LabelNode) : contents;
+
+/**
+ * Trim all trailing whitespace at the end of the current line. Used for
+ * removing extra indentation on blank lines.
+ */
+export const trim: TrimNode = { type: 'trim' };
+
+/**
+ * Placeholder for cursor position tracking. After layout, the result
+ * reports the cursor offset in the output string. Can be used to maintain
+ * cursor position after formatting.
+ *
+ * @todo Rename to "sentinel"?
+ */
+export const cursor: CursorNode = { type: 'cursor' };
+
+/**
+ * Join an array of docs with a separator doc between each pair.
+ */
+export const join = (separator: Doc, docs: Doc[]): Doc[] => {
+  const parts: Doc[] = [];
+
+  for (let i = 0; i < docs.length; i++) {
+    if (i > 0) parts.push(separator);
+    parts.push(docs[i]);
+  }
+
+  return parts;
+};
+
+/**
+ * Common pattern: a bracketed, optionally-indented list.
+ *
+ * ```ts
+ * bracketedList("(", ")", ",", [a, b, c])
+ * ```
+ *
+ * Flat:  `(a, b, c)`.
+ *
+ * Broken:
+ *
+ * ```
+ * (
+ *   a,
+ *   b,
+ *   c
+ * )
+ * ```
+ */
+export const bracketedList = (
+  open: string,
+  close: string,
+  separator: string,
+  items: Doc[]
+): Doc => {
+  if (items.length === 0) return [open, close];
+
+  return group([
+    text(open),
+    indent([softline, join([text(separator), line], items)]),
+    softline,
+    text(close),
+  ]);
+};
+
+/**
+ * Convert an absolute indentation size into a combination of `indent` (for
+ * tab-sized chunks) and `align` (for remaining spaces), wrapped in
+ * `dedentToRoot`. Used for embedded content that needs a specific indentation
+ * level.
+ */
+export const addAlignmentToDoc = (doc: Doc, size: number, tabWidth: number): Doc => {
+  let aligned = doc;
+
+  if (size > 0) {
+    for (let i = 0; i < Math.floor(size / tabWidth); i++) {
+      aligned = indent(aligned);
+    }
+
+    const remainder = size % tabWidth;
+
+    if (remainder > 0) {
+      aligned = align(remainder, aligned);
+    }
+    aligned = dedentToRoot(aligned);
+  }
+
+  return aligned;
+};

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type * from './types';
+export * from './builders';
+export * from './traversal';
+export * from './layout';

--- a/src/printer/layout.ts
+++ b/src/printer/layout.ts
@@ -1,0 +1,496 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { hardlineWithoutBreakParent } from './builders';
+import { propagateBreaks } from './prepare';
+import type { Doc, FillNode } from './types';
+
+enum Mode {
+  Flat,
+  Break,
+}
+
+class Indent {
+  constructor(
+    /** Total number of characters this indent occupies. */
+    public readonly length: number,
+    /** The actual whitespace string to emit. */
+    public readonly value: string,
+    /** Root indent level saved by `markAsRoot`, used by `literalline`. */
+    public readonly root?: Indent
+  ) {}
+}
+
+const makeIndent = (current: Indent, options: { tabWidth: number; useTabs: boolean }): Indent => {
+  const added = options.useTabs ? '\t' : ' '.repeat(options.tabWidth);
+  return new Indent(current.length + options.tabWidth, current.value + added, current.root);
+};
+
+const makeAlign = (current: Indent, n: number | { type: 'root' }): Indent => {
+  if (typeof n === 'object' && n.type === 'root') {
+    return new Indent(current.length, current.value, current);
+  }
+
+  if (n === Number.NEGATIVE_INFINITY) {
+    return current.root ?? new Indent(0, '');
+  }
+
+  if (typeof n === 'number' && n < 0) {
+    return new Indent(
+      Math.max(0, current.length + n),
+      current.value.slice(0, Math.max(0, current.value.length + n)),
+      current.root
+    );
+  }
+
+  return new Indent(
+    current.length + (n as number),
+    current.value + ' '.repeat(n as number),
+    current.root
+  );
+};
+
+interface Command {
+  readonly indent: Indent;
+  readonly mode: Mode;
+  readonly doc: Doc;
+}
+
+const cmd = (indent: Indent, mode: Mode, doc: Doc): Command => ({ indent, mode, doc });
+
+/**
+ * Simulates flat-mode rendering to check whether a group's contents fit
+ * within the remaining line width. Does not produce output — only measures.
+ */
+const fits = (
+  next: Command,
+  restCommands: readonly Command[],
+  remainingWidth: number,
+  hasLineSuffix: boolean,
+  groupModeMap: Record<symbol, Mode>
+): boolean => {
+  if (remainingWidth === Infinity) return true;
+
+  let restIdx = restCommands.length;
+  let width = remainingWidth;
+  const stack: Command[] = [next];
+
+  while (width >= 0) {
+    if (stack.length === 0) {
+      if (restIdx === 0) return true;
+      stack.push(restCommands[--restIdx]);
+      continue;
+    }
+
+    const { indent, mode, doc } = stack.pop()!;
+
+    if (typeof doc === 'string') {
+      if (doc) width -= stringWidth(doc);
+      continue;
+    }
+
+    if (Array.isArray(doc)) {
+      for (let i = doc.length - 1; i >= 0; i--) {
+        stack.push(cmd(indent, mode, doc[i]));
+      }
+      continue;
+    }
+
+    switch (doc.type) {
+      case 'indent':
+      case 'align':
+      case 'label':
+        stack.push(cmd(indent, mode, doc.contents));
+        break;
+
+      case 'group': {
+        const groupMode = doc.shouldBreak ? Mode.Break : mode;
+        stack.push(cmd(indent, groupMode, doc.contents));
+        break;
+      }
+
+      case 'fill':
+        for (let i = doc.parts.length - 1; i >= 0; i--) {
+          stack.push(cmd(indent, mode, doc.parts[i]));
+        }
+        break;
+
+      case 'if-break': {
+        const groupMode = doc.groupId ? (groupModeMap[doc.groupId] ?? Mode.Flat) : mode;
+        const contents = groupMode === Mode.Break ? doc.breakContents : doc.flatContents;
+        if (contents) stack.push(cmd(indent, mode, contents));
+        break;
+      }
+
+      case 'indent-if-break':
+        stack.push(cmd(indent, mode, doc.contents));
+        break;
+
+      case 'line':
+        if (mode === Mode.Break || doc.hard) return true;
+        if (!doc.soft) width -= 1;
+        break;
+
+      case 'line-suffix':
+        hasLineSuffix = true;
+        break;
+
+      case 'line-suffix-boundary':
+        if (hasLineSuffix) return false;
+        break;
+
+      case 'trim':
+      case 'cursor':
+      case 'break-parent':
+        break;
+    }
+  }
+
+  return false;
+};
+
+const layoutFill = (
+  parts: Doc[],
+  indentVal: Indent,
+  mode: Mode,
+  commands: Command[],
+  printWidth: number,
+  position: number,
+  lineSuffixBuffer: Command[],
+  groupModeMap: Record<symbol, Mode>
+): void => {
+  const length = parts.length;
+  if (length === 0) return;
+
+  const content = parts[0];
+  const whitespace = parts[1];
+
+  const contentFlatCmd = cmd(indentVal, Mode.Flat, content);
+  const contentBreakCmd = cmd(indentVal, Mode.Break, content);
+  const remaining = printWidth - position;
+  const hasLS = lineSuffixBuffer.length > 0;
+
+  const contentFits = fits(contentFlatCmd, [], remaining, hasLS, groupModeMap);
+
+  if (length === 1) {
+    commands.push(contentFits ? contentFlatCmd : contentBreakCmd);
+    return;
+  }
+
+  const whitespaceFlatCmd = cmd(indentVal, Mode.Flat, whitespace);
+  const whitespaceBreakCmd = cmd(indentVal, Mode.Break, whitespace);
+
+  if (length === 2) {
+    commands.push(
+      contentFits ? whitespaceFlatCmd : whitespaceBreakCmd,
+      contentFits ? contentFlatCmd : contentBreakCmd
+    );
+    return;
+  }
+
+  const restCmd = cmd(indentVal, mode, { type: 'fill', parts: parts.slice(2) } as FillNode);
+
+  const secondContent = parts[2];
+  const bothFitFlat = fits(
+    cmd(indentVal, Mode.Flat, [content, whitespace, secondContent]),
+    [],
+    remaining,
+    hasLS,
+    groupModeMap
+  );
+
+  commands.push(restCmd);
+
+  if (bothFitFlat) {
+    commands.push(whitespaceFlatCmd, contentFlatCmd);
+  } else if (contentFits) {
+    commands.push(whitespaceBreakCmd, contentFlatCmd);
+  } else {
+    commands.push(whitespaceBreakCmd, contentBreakCmd);
+  }
+};
+
+const CURSOR_PLACEHOLDER = Symbol.for('cursor');
+
+interface LayoutInternalOpts {
+  readonly printWidth: number;
+  readonly tabWidth: number;
+  readonly useTabs: boolean;
+  readonly endOfLine: string;
+}
+
+const resolveOptions = (opts?: LayoutOpts): LayoutInternalOpts => ({
+  printWidth: opts?.printWidth ?? 80,
+  tabWidth: opts?.tabWidth ?? 2,
+  useTabs: opts?.useTabs ?? false,
+  endOfLine: opts?.endOfLine ?? '\n',
+});
+
+const stringWidth = (s: string): number => s.length;
+
+// ----------------------------------------------------------------- Public API
+
+/**
+ * Options accepted by the public API. All fields are optional with defaults.
+ */
+export interface LayoutOpts {
+  /**
+   * Maximum line width before the engine attempts to break groups.
+   * @default 80
+   */
+  printWidth?: number;
+
+  /**
+   * Number of spaces per indentation level.
+   * @default 2
+   */
+  tabWidth?: number;
+
+  /**
+   * Use tab characters for indentation instead of spaces.
+   * @default false
+   */
+  useTabs?: boolean;
+
+  /**
+   * End-of-line character(s).
+   * @default '\n'
+   */
+  endOfLine?: '\n' | '\r\n' | '\r';
+}
+
+/**
+ * The layout algorithm. Takes a pretty-print doc tree and options, and produces
+ * a concrete string with optimal line breaks.
+ */
+export const layout = (doc: Doc, opts?: LayoutOpts): string => {
+  const options = resolveOptions(opts);
+  const { printWidth, endOfLine } = options;
+  const rootIndent = new Indent(0, '');
+
+  const groupModeMap: Record<symbol, Mode> = Object.create(null);
+
+  let output = '';
+  let position = 0;
+  let shouldRemeasure = false;
+
+  const commands: Command[] = [cmd(rootIndent, Mode.Break, doc)];
+  const lineSuffixBuffer: Command[] = [];
+
+  propagateBreaks(doc);
+
+  while (commands.length > 0) {
+    const { indent: indentVal, mode, doc: currentDoc } = commands.pop()!;
+
+    if (typeof currentDoc === 'string') {
+      if (currentDoc) {
+        output += currentDoc;
+        position += stringWidth(currentDoc);
+      }
+      continue;
+    }
+
+    if (Array.isArray(currentDoc)) {
+      for (let i = currentDoc.length - 1; i >= 0; i--) {
+        commands.push(cmd(indentVal, mode, currentDoc[i]));
+      }
+      continue;
+    }
+
+    switch (currentDoc.type) {
+      case 'indent':
+        commands.push(cmd(makeIndent(indentVal, options), mode, currentDoc.contents));
+        break;
+
+      case 'align':
+        commands.push(cmd(makeAlign(indentVal, currentDoc.n), mode, currentDoc.contents));
+        break;
+
+      case 'group': {
+        if (mode === Mode.Flat && !shouldRemeasure) {
+          commands.push(
+            cmd(indentVal, currentDoc.shouldBreak ? Mode.Break : Mode.Flat, currentDoc.contents)
+          );
+        } else if (!currentDoc.expandedStates) {
+          shouldRemeasure = false;
+          const groupMode =
+            currentDoc.shouldBreak ||
+            !fits(
+              cmd(indentVal, Mode.Flat, currentDoc.contents),
+              commands,
+              printWidth - position,
+              lineSuffixBuffer.length > 0,
+              groupModeMap
+            )
+              ? Mode.Break
+              : Mode.Flat;
+
+          commands.push(cmd(indentVal, groupMode, currentDoc.contents));
+
+          if (currentDoc.id) {
+            groupModeMap[currentDoc.id] = groupMode;
+          }
+        } else {
+          shouldRemeasure = false;
+          const remaining = printWidth - position;
+          const hasLS = lineSuffixBuffer.length > 0;
+
+          if (
+            fits(
+              cmd(indentVal, Mode.Flat, currentDoc.contents),
+              commands,
+              remaining,
+              hasLS,
+              groupModeMap
+            )
+          ) {
+            commands.push(cmd(indentVal, Mode.Flat, currentDoc.contents));
+          } else {
+            let matched = false;
+            for (const state of currentDoc.expandedStates) {
+              if (state === currentDoc.expandedStates[currentDoc.expandedStates.length - 1]) {
+                commands.push(cmd(indentVal, Mode.Break, state));
+                matched = true;
+                break;
+              }
+              if (
+                fits(cmd(indentVal, Mode.Flat, state), commands, remaining, hasLS, groupModeMap)
+              ) {
+                commands.push(cmd(indentVal, Mode.Flat, state));
+                matched = true;
+                break;
+              }
+            }
+            if (!matched) {
+              commands.push(cmd(indentVal, Mode.Break, currentDoc.contents));
+            }
+          }
+
+          if (currentDoc.id) {
+            groupModeMap[currentDoc.id] = commands[commands.length - 1].mode;
+          }
+        }
+        break;
+      }
+
+      case 'fill':
+        layoutFill(
+          currentDoc.parts,
+          indentVal,
+          mode,
+          commands,
+          printWidth,
+          position,
+          lineSuffixBuffer,
+          groupModeMap
+        );
+        break;
+
+      case 'if-break': {
+        const groupMode = currentDoc.groupId
+          ? (groupModeMap[currentDoc.groupId] ?? Mode.Flat)
+          : mode;
+        const contents =
+          groupMode === Mode.Break ? currentDoc.breakContents : currentDoc.flatContents;
+        if (contents) {
+          commands.push(cmd(indentVal, mode, contents));
+        }
+        break;
+      }
+
+      case 'indent-if-break': {
+        const refMode = groupModeMap[currentDoc.groupId] ?? Mode.Flat;
+        const shouldApplyIndent = currentDoc.negate
+          ? refMode === Mode.Flat
+          : refMode === Mode.Break;
+        commands.push(
+          cmd(
+            shouldApplyIndent ? makeIndent(indentVal, options) : indentVal,
+            mode,
+            currentDoc.contents
+          )
+        );
+        break;
+      }
+
+      case 'cursor':
+        output += CURSOR_PLACEHOLDER.toString();
+        break;
+
+      case 'line-suffix':
+        lineSuffixBuffer.push(cmd(indentVal, mode, currentDoc.contents));
+        break;
+
+      case 'line-suffix-boundary':
+        if (lineSuffixBuffer.length > 0) {
+          commands.push(cmd(indentVal, mode, hardlineWithoutBreakParent));
+        }
+        break;
+
+      case 'line':
+        switch (mode) {
+          case Mode.Flat:
+            if (currentDoc.hard) {
+              shouldRemeasure = true;
+            } else {
+              if (!currentDoc.soft) {
+                output += ' ';
+                position += 1;
+              }
+              break;
+            }
+          // falls through (hardline in flat mode)
+
+          case Mode.Break:
+            if (lineSuffixBuffer.length > 0) {
+              commands.push(cmd(indentVal, mode, currentDoc));
+              commands.push(...lineSuffixBuffer.reverse());
+              lineSuffixBuffer.length = 0;
+              break;
+            }
+            if (currentDoc.literal) {
+              output += endOfLine;
+              if (indentVal.root) {
+                output += indentVal.root.value;
+                position = indentVal.root.length;
+              } else {
+                position = 0;
+              }
+            } else {
+              output += endOfLine + indentVal.value;
+              position = indentVal.length;
+            }
+            break;
+        }
+        break;
+
+      case 'label':
+        commands.push(cmd(indentVal, mode, currentDoc.contents));
+        break;
+
+      case 'trim': {
+        let trimmed = 0;
+        while (output.length > 0 && output[output.length - 1] === ' ') {
+          output = output.slice(0, -1);
+          trimmed++;
+        }
+        position -= trimmed;
+        break;
+      }
+
+      case 'break-parent':
+        break;
+    }
+
+    if (commands.length === 0 && lineSuffixBuffer.length > 0) {
+      commands.push(...lineSuffixBuffer.reverse());
+      lineSuffixBuffer.length = 0;
+    }
+  }
+
+  return output;
+};

--- a/src/printer/prepare.ts
+++ b/src/printer/prepare.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { traverse } from './traversal';
+import type { Doc, GroupNode } from './types';
+
+/**
+ * A pre-pass that mutates `shouldBreak` on `GroupDoc` nodes. For example,
+ * forces all ancestor groups of any `breakParent` command to break. This
+ * ensures that a `hardline` deep inside a group hierarchy propagates upward
+ * correctly.
+ */
+export const propagateBreaks = (doc: Doc): void => {
+  const groupStack: GroupNode[] = [];
+  const visited = new WeakSet<GroupNode>();
+
+  traverse(doc, {
+    onEnter(node) {
+      if (typeof node === 'string' || Array.isArray(node)) return;
+
+      switch (node.type) {
+        case 'break-parent': {
+          // Mark the nearest ancestor group for wrapping/breaking.
+          if (groupStack.length > 0) {
+            const parent = groupStack[groupStack.length - 1];
+
+            if (parent) parent.shouldBreak = true;
+          }
+          break;
+        }
+        case 'group': {
+          groupStack.push(node);
+          if (visited.has(node)) return false;
+          visited.add(node);
+          break;
+        }
+      }
+    },
+
+    onExit(node) {
+      if (typeof node === 'string' || Array.isArray(node)) return;
+
+      switch (node.type) {
+        case 'group': {
+          const grp = groupStack.pop();
+
+          // If this group broke, propagate to its parent.
+          if (grp && grp.shouldBreak && groupStack.length > 0) {
+            const parent = groupStack[groupStack.length - 1];
+
+            if (parent) parent.shouldBreak = true;
+          }
+          break;
+        }
+      }
+    },
+  });
+};

--- a/src/printer/traversal.ts
+++ b/src/printer/traversal.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Doc } from './types';
+
+/** Sentinel used to mark the position where onExit should fire. */
+class ExitMarker {
+  constructor(public readonly node: Doc) {}
+}
+
+export interface TraverseOpts {
+  /** Called when entering a node. Return `false` to skip its children. */
+  onEnter?(doc: Doc): false | void;
+  /** Called when leaving a node. */
+  onExit?(doc: Doc): void;
+}
+
+/**
+ * Generic depth-first traversal of a print tree. Uses an explicit stack
+ * (no recursion) traversal.
+ */
+export const traverse = (doc: Doc, callbacks: TraverseOpts): void => {
+  const hasExit = typeof callbacks.onExit === 'function';
+  const stack: Array<Doc | ExitMarker> = [doc];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+
+    if (current instanceof ExitMarker) {
+      callbacks.onExit?.(current.node);
+      continue;
+    }
+
+    const result = callbacks.onEnter?.(current);
+    if (result === false) continue; // skip children
+
+    if (typeof current === 'string') {
+      if (hasExit) callbacks.onExit?.(current);
+      continue;
+    }
+
+    if (Array.isArray(current)) {
+      if (hasExit) {
+        stack.push(new ExitMarker(current));
+      }
+      for (let i = current.length - 1; i >= 0; i--) {
+        stack.push(current[i]);
+      }
+      continue;
+    }
+
+    if (hasExit) {
+      stack.push(new ExitMarker(current));
+    }
+
+    switch (current.type) {
+      case 'group':
+      case 'indent':
+      case 'indent-if-break':
+      case 'align':
+      case 'label':
+      case 'line-suffix':
+        if ('contents' in current && current.contents) {
+          stack.push(current.contents);
+        }
+        break;
+      case 'fill':
+        for (let i = current.parts.length - 1; i >= 0; i--) {
+          stack.push(current.parts[i]);
+        }
+        break;
+      case 'if-break':
+        if (current.flatContents) stack.push(current.flatContents);
+        if (current.breakContents) stack.push(current.breakContents);
+        break;
+    }
+  }
+};

--- a/src/printer/types.ts
+++ b/src/printer/types.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * The document intermediate representation.
+ *
+ * - `string` — literal text (must not contain newline characters).
+ * - `Doc[]` — concatenation of documents, rendered left to right.
+ * - `DocNode` — a formatting instruction node.
+ */
+export type Doc = string | Doc[] | AnyNode;
+
+/**
+ * All possible document nodes.
+ */
+export type AnyNode =
+  | GroupNode
+  | FillNode
+  | IndentNode
+  | IndentIfBreakNode
+  | AlignNode
+  | IfBreakNode
+  | LineNode
+  | LineSuffixNode
+  | LineSuffixBoundaryNode
+  | BreakParentNode
+  | LabelNode
+  | TrimNode
+  | CursorNode;
+
+/**
+ * The core break-decision unit. The layout engine first tries to render
+ * `contents` entirely on one line (flat mode). If the result exceeds the
+ * remaining line width, it switches to break mode — replacing every `line`
+ * and `softline` inside with a newline + indentation.
+ *
+ * When `expandedStates` is provided this becomes a **conditional group**:
+ * the engine tries each state in order (most compact first) and uses the first
+ * one that fits. If none fits, the last state is rendered in break mode.
+ *
+ * Setting `shouldBreak` to `true` forces break mode unconditionally.
+ *
+ * An `id` allows other commands (`ifBreak`, `indentIfBreak`) to query
+ * this group's resolved mode.
+ */
+export interface GroupNode {
+  readonly type: 'group';
+  readonly contents: Doc;
+  readonly id?: symbol;
+  readonly expandedStates?: readonly Doc[];
+  shouldBreak?: boolean;
+}
+
+/**
+ * Wrapping layout: packs as many items per line as possible, breaking to a
+ * new line only when the next item would exceed the line width.
+ *
+ * `parts` must alternate between content docs and line-break docs:
+ * `[item1, line, item2, line, item3, ...]`
+ *
+ * Unlike `group` (all-or-nothing), `fill` makes per-item break decisions,
+ * producing partially filled lines.
+ */
+export interface FillNode {
+  readonly type: 'fill';
+  readonly parts: Doc[];
+}
+
+/**
+ * Increases indentation by one tab level for `contents`.
+ */
+export interface IndentNode {
+  readonly type: 'indent';
+  readonly contents: Doc;
+}
+
+/**
+ * Conditionally indents `contents` based on whether the group identified
+ * by `groupId` is in break mode.
+ *
+ * When `negate` is `true` the behavior is inverted: indent when the
+ * referenced group is flat, don't indent when broken.
+ */
+export interface IndentIfBreakNode {
+  readonly type: 'indent-if-break';
+  readonly contents: Doc;
+  readonly groupId: symbol;
+  readonly negate?: boolean;
+}
+
+/**
+ * Increases indentation by a fixed number of spaces rather than a full
+ * tab level. Useful for alignment that doesn't match the configured tab
+ * width.
+ *
+ * Special values for `n`:
+ *
+ * - Positive integer — add `n` spaces of alignment.
+ * - `-1` — dedent by one level (reverses one `indent` or `align`).
+ * - `Number.NEGATIVE_INFINITY` — reset indentation to the root level.
+ * - `{ type: 'root' }` — mark current indentation as the root position
+ *   for `literalline`.
+ */
+export interface AlignNode {
+  readonly type: 'align';
+  readonly n: number | { type: 'root' };
+  readonly contents: Doc;
+}
+
+/**
+ * Emits `breakContents` when the enclosing group (or the group identified
+ * by `groupId`) is in break mode, or `flatContents` when it renders flat.
+ *
+ * Common use cases: trailing commas only in broken lists, different
+ * separators depending on layout mode.
+ */
+export interface IfBreakNode {
+  readonly type: 'if-break';
+  readonly breakContents: Doc;
+  readonly flatContents: Doc;
+  readonly groupId?: symbol;
+}
+
+/**
+ * A line-break command whose behavior depends on the enclosing group's mode:
+ *
+ * | `soft` | `hard` | `literal` | Flat mode        | Break mode         |
+ * |--------|--------|-----------|------------------|--------------------|
+ * | false  | false  | false     | space `" "`      | newline + indent   | `line`
+ * | true   | false  | false     | nothing `""`     | newline + indent   | `softline`
+ * | false  | true   | false     | newline + indent | newline + indent   | `hardline`
+ * | false  | true   | true      | newline + root   | newline + root     | `literalline`
+ *
+ * When `literal` is `true`, the newline preserves trailing whitespace on
+ * the preceding line and indents to the root position (set by `markAsRoot`)
+ * rather than the current nesting level. Used for embedded/template content.
+ */
+export interface LineNode {
+  readonly type: 'line';
+  readonly soft?: boolean;
+  readonly hard?: boolean;
+  readonly literal?: boolean;
+}
+
+/**
+ * Buffers `contents` and emits them at the end of the current line, just
+ * before the next line break. Used for trailing comments.
+ *
+ * Example: `[text("x"), lineSuffix(" // comment"), text(";"), hardline]`
+ * produces: `x; // comment\n`
+ *
+ * Without `lineSuffix`, the comment would appear before the semicolon.
+ */
+export interface LineSuffixNode {
+  readonly type: 'line-suffix';
+  readonly contents: Doc;
+}
+
+/**
+ * Forces any buffered `lineSuffix` content to be flushed at this point
+ * rather than waiting for a natural line break. Prevents trailing comments
+ * from leaking across syntactic boundaries (e.g., past a closing brace).
+ */
+export interface LineSuffixBoundaryNode {
+  readonly type: 'line-suffix-boundary';
+}
+
+/**
+ * Forces all ancestor groups to break. Paired with `hardline` to ensure
+ * that a hard line break propagates upward through the group hierarchy.
+ *
+ * Processed during the `propagateBreaks` pre-pass which walks the Doc
+ * tree and sets `shouldBreak` on every enclosing `GroupDoc`.
+ */
+export interface BreakParentNode {
+  readonly type: 'break-parent';
+}
+
+/**
+ * Annotates a doc with an opaque label for heuristic introspection by
+ * language-specific printers. Has no effect on layout. Useful when a
+ * printer needs to inspect sub-docs.
+ */
+export interface LabelNode {
+  readonly type: 'label';
+  readonly label: unknown;
+  readonly contents: Doc;
+}
+
+/**
+ * Removes trailing whitespace from the output at the current position.
+ */
+export interface TrimNode {
+  readonly type: 'trim';
+}
+
+/**
+ * Placeholder for cursor position tracking. The layout engine emits a
+ * sentinel character at this position; after layout, the caller can
+ * locate the cursor in the output string. Useful for editor
+ * format-on-save integrations that need to preserve cursor position.
+ */
+export interface CursorNode {
+  readonly type: 'cursor';
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import type { PromQLAstQueryExpression } from './embedded_languages/promql/types';
 
 /**


### PR DESCRIPTION
## Summary

Partially addresses: https://github.com/elastic/kibana/issues/242923

See [README](https://github.com/elastic/esql-js/blob/79aefa0c8ae438e29af90ace93780b2f61ecdcf1/src/printer/README.md) for detailed description of this library.

Below is an example of how the printer works in a nutshell:

```ts
import { text, group, indent, line, softline, join, layout } from './printer';

const doc = group([
  text('SELECT'),
  indent([line, join(
    [text(','), line],
    [text('a'), text('b'), text('c')]
  )]),
  line,
  text('FROM t'),
]);

layout(doc, { printWidth: 40 });
// SELECT
//   a,
//   b,
//   c
// FROM t

layout(doc, { printWidth: 80 });
// SELECT a, b, c FROM t
```

## Details

Technical details, breaking changes or considerations you have made while working in this PR.

<!-- BREAKING CHANGE: explain breaking changes added in this PR. -->

### Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Unit tests have been added or updated.
- [x] The proper documentation has been added or updated.
- [x] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax.
- [x] The PR title has the correct [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) label in the title, this is crucial for the correct versioning of this package. Check the following cheat shit.
  | Title Label | Release |
  |---|---|
  | `breaking: true (!)` | `major` |
  | `feat` | `minor` |
  | `fix` | `patch` |
  | `refactor` | `patch` |
  | `perf` | `patch` |
  | `build` | `patch` |
  | `docs`  | `patch` |
  | `chore` | `patch` |
  | `revert` | `patch` |
