### PR TITLE
feat: Support METRICS_INFO in AST & APIs

### DIFF
--- a/src/ast/visitor/contexts.ts
+++ b/src/ast/visitor/contexts.ts
@@ -18,6 +18,7 @@ import type {
   ESQLAstHeaderCommand,
   ESQLAstItem,
   ESQLAstJoinCommand,
+  ESQLAstMetricsInfoCommand,
   ESQLAstQueryExpression,
   ESQLAstRegisteredDomainCommand,
   ESQLAstRerankCommand,
@@ -592,6 +593,12 @@ export class UriPartsCommandVisitorContext<
   Methods extends VisitorMethods = VisitorMethods,
   Data extends SharedData = SharedData,
 > extends CommandVisitorContext<Methods, Data, ESQLAstUriPartsCommand> {}
+
+// METRICS_INFO
+export class MetricsInfoCommandVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData,
+> extends CommandVisitorContext<Methods, Data, ESQLAstMetricsInfoCommand> {}
 
 // Expressions -----------------------------------------------------------------
 

--- a/src/ast/visitor/global_visitor_context.ts
+++ b/src/ast/visitor/global_visitor_context.ts
@@ -12,6 +12,7 @@ import type {
   ESQLAstCompletionCommand,
   ESQLAstHeaderCommand,
   ESQLAstJoinCommand,
+  ESQLAstMetricsInfoCommand,
   ESQLAstQueryExpression,
   ESQLAstRegisteredDomainCommand,
   ESQLAstRerankCommand,
@@ -236,6 +237,14 @@ export class GlobalVisitorContext<
         return this.visitUriPartsCommand(
           parent,
           commandNode as ESQLAstUriPartsCommand,
+          input as any
+        );
+      }
+      case 'metrics_info': {
+        if (!this.methods.visitMetricsInfoCommand) break;
+        return this.visitMetricsInfoCommand(
+          parent,
+          commandNode as ESQLAstMetricsInfoCommand,
           input as any
         );
       }
@@ -525,6 +534,15 @@ export class GlobalVisitorContext<
   ): types.VisitorOutput<Methods, 'visitUriPartsCommand'> {
     const context = new contexts.UriPartsCommandVisitorContext(this, node, parent);
     return this.visitWithSpecificContext('visitUriPartsCommand', context, input);
+  }
+
+  public visitMetricsInfoCommand(
+    parent: contexts.VisitorContext | null,
+    node: ESQLAstMetricsInfoCommand,
+    input: types.VisitorInput<Methods, 'visitMetricsInfoCommand'>
+  ): types.VisitorOutput<Methods, 'visitMetricsInfoCommand'> {
+    const context = new contexts.MetricsInfoCommandVisitorContext(this, node, parent);
+    return this.visitWithSpecificContext('visitMetricsInfoCommand', context, input);
   }
 
   // #endregion

--- a/src/ast/visitor/types.ts
+++ b/src/ast/visitor/types.ts
@@ -112,6 +112,7 @@ export type CommandVisitorInput<Methods extends VisitorMethods> = AnyToVoid<
     VisitorInput<Methods, 'visitRerankCommand'> &
     VisitorInput<Methods, 'visitChangePointCommand'> &
     VisitorInput<Methods, 'visitUriPartsCommand'> &
+    VisitorInput<Methods, 'visitMetricsInfoCommand'> &
     VisitorInput<Methods, 'visitRegisteredDomainCommand'>
 >;
 
@@ -145,6 +146,7 @@ export type CommandVisitorOutput<Methods extends VisitorMethods> =
   | VisitorOutput<Methods, 'visitChangePointCommand'>
   | VisitorOutput<Methods, 'visitCompletionCommand'>
   | VisitorOutput<Methods, 'visitUriPartsCommand'>
+  | VisitorOutput<Methods, 'visitMetricsInfoCommand'>
   | VisitorOutput<Methods, 'visitRegisteredDomainCommand'>;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -206,6 +208,11 @@ export interface VisitorMethods<
   visitFuseCommand?: Visitor<contexts.FuseCommandVisitorContext<Visitors, Data>, any, any>;
   visitMmrCommand?: Visitor<contexts.MmrCommandVisitorContext<Visitors, Data>, any, any>;
   visitUriPartsCommand?: Visitor<contexts.UriPartsCommandVisitorContext<Visitors, Data>, any, any>;
+  visitMetricsInfoCommand?: Visitor<
+    contexts.MetricsInfoCommandVisitorContext<Visitors, Data>,
+    any,
+    any
+  >;
   visitExpression?: Visitor<contexts.ExpressionVisitorContext<Visitors, Data>, any, any>;
   visitSourceExpression?: Visitor<
     contexts.SourceExpressionVisitorContext<Visitors, Data>,

--- a/src/parser/__tests__/metrics_info.test.ts
+++ b/src/parser/__tests__/metrics_info.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EsqlQuery } from '../../composer/query';
+import { Walker } from '../../ast/walker';
+import type { ESQLAstQueryExpression, ESQLAstMetricsInfoCommand } from '../../types';
+
+describe('METRICS_INFO', () => {
+  const getMetricsInfo = (ast: ESQLAstQueryExpression): ESQLAstMetricsInfoCommand =>
+    Walker.match(ast, {
+      type: 'command',
+      name: 'metrics_info',
+    }) as ESQLAstMetricsInfoCommand;
+
+  it('parses metrics_info command', () => {
+    const src = `TS index | metrics_info`;
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const metricsInfo = getMetricsInfo(ast);
+
+    expect(errors.length).toBe(0);
+    expect(metricsInfo).toMatchObject({
+      type: 'command',
+      name: 'metrics_info',
+      incomplete: false,
+    });
+    expect(metricsInfo.args).toHaveLength(0);
+  });
+});

--- a/src/parser/core/cst_to_ast_converter.ts
+++ b/src/parser/core/cst_to_ast_converter.ts
@@ -523,6 +523,12 @@ export class CstToAstConverter {
     if (uriPartsCommandCtx) {
       return this.fromUriPartsCommand(uriPartsCommandCtx);
     }
+
+    const metricsInfoCommandCtx = ctx.metricsInfoCommand();
+
+    if (metricsInfoCommandCtx) {
+      return this.fromMetricsInfoCommand(metricsInfoCommandCtx);
+    }
     // throw new Error(`Unknown processing command: ${this.getSrc(ctx)}`;
   }
 
@@ -2293,6 +2299,15 @@ export class CstToAstConverter {
 
     return command;
   }
+
+  // --------------------------------------------------------------- METRICS_INFO
+
+  private fromMetricsInfoCommand(
+    ctx: cst.MetricsInfoCommandContext
+  ): ast.ESQLAstMetricsInfoCommand {
+    return this.createCommand<'metrics_info', ast.ESQLAstMetricsInfoCommand>('metrics_info', ctx);
+  }
+
   // -------------------------------------------------------------- expressions
 
   private toColumnsFromCommand(

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type ESQLAstCommand =
   | ESQLAstFuseCommand
   | ESQLAstForkCommand
   | ESQLAstUriPartsCommand
+  | ESQLAstMetricsInfoCommand
   | ESQLAstRegisteredDomainCommand;
 
 export type ESQLAstAllCommands = ESQLAstCommand | ESQLAstHeaderCommand;
@@ -163,6 +164,8 @@ export interface ESQLAstUriPartsCommand extends ESQLCommand<'uri_parts'> {
   targetField: ESQLColumn;
   expression?: ESQLAstExpression;
 }
+
+export interface ESQLAstMetricsInfoCommand extends ESQLCommand<'metrics_info'> {}
 
 export interface ESQLAstRegisteredDomainCommand extends ESQLCommand<'registered_domain'> {
   targetField: ESQLColumn;


### PR DESCRIPTION
part of: https://github.com/elastic/kibana/issues/255433

## Summary

This PR adds AST support for the new METRICS_INFO command as well as support in the visitor API

## Details

- cast_to_ast_converter: just creates the command with the context since the grammar is just:
```
metricsInfoCommand
    : METRICS_INFO
    ;
```

- global_visitor_context: adds the `visitMetricsInfoCommand` in the same way as the other commands along with its types.

### Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Unit tests have been added or updated.
- [x] The PR title has the correct [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) label in the title, this is crucial for the correct versioning of this package. Check the following cheat shit.
  | Title Label | Release |
  |---|---|
  | `breaking: true (!)` | `major` |
  | `feat` | `minor` |
  | `fix` | `patch` |
  | `refactor` | `patch` |
  | `perf` | `patch` |
  | `build` | `patch` |
  | `docs`  | `patch` |
  | `chore` | `patch` |
  | `revert` | `patch` |
