### PR TITLE
feat: Add mutation functions for SETtings

### DIFF
--- a/src/ast/mutate/README.md
+++ b/src/ast/mutate/README.md
@@ -66,5 +66,9 @@ console.log(src); // FROM index METADATA _lang, _id
   - `.join`
     - `.list()` &mdash; List all `JOIN` commands.
     - `.byIndex()` &mdash; Find a `JOIN` command by index.
-
+  - `.set`
+    - `.list()` &mdash; List all `SET` header commands.
+    - `.findBySettingName()` &mdash; Find a `SET` command by its setting name.
+    - `.set()` &mdash; Modify the value of an existing `SET` setting.
+    - `.upsert()` &mdash; Modify a `SET` setting value, or add a new `SET` command if it does not exist.
 

--- a/src/ast/mutate/README.md
+++ b/src/ast/mutate/README.md
@@ -69,6 +69,6 @@ console.log(src); // FROM index METADATA _lang, _id
   - `.set`
     - `.list()` &mdash; List all `SET` header commands.
     - `.findBySettingName()` &mdash; Find a `SET` command by its setting name.
-    - `.set()` &mdash; Modify the value of an existing `SET` setting.
+    - `.update()` &mdash; Modify the value of an existing `SET` setting.
     - `.upsert()` &mdash; Modify a `SET` setting value, or add a new `SET` command if it does not exist.
-
+    - `.remove()` &mdash; Deletes a SET command by setting name.

--- a/src/ast/mutate/commands/index.ts
+++ b/src/ast/mutate/commands/index.ts
@@ -7,10 +7,11 @@
 
 import * as from from './from';
 import * as limit from './limit';
+import * as set from './set';
 import * as sort from './sort';
 import * as stats from './stats';
 import * as where from './where';
 import * as join from './join';
 import * as rerank from './rerank';
 
-export { from, limit, sort, stats, where, join, rerank };
+export { from, limit, set, sort, stats, where, join, rerank };

--- a/src/ast/mutate/commands/set/index.test.ts
+++ b/src/ast/mutate/commands/set/index.test.ts
@@ -64,12 +64,12 @@ describe('commands.set', () => {
     });
   });
 
-  describe('.set()', () => {
+  describe('.update()', () => {
     it('modifies the value of an existing setting', () => {
       const src = 'SET unmapped_fields = "DEFAULT"; FROM index';
       const { root } = Parser.parse(src);
 
-      commands.set.set(root, 'unmapped_fields', 'LOAD');
+      commands.set.update(root, 'unmapped_fields', 'LOAD');
       const printed = BasicPrettyPrinter.print(root);
 
       expect(printed).toBe('SET unmapped_fields = "LOAD"; FROM index');
@@ -79,7 +79,7 @@ describe('commands.set', () => {
       const src = 'SET approximation = TRUE; FROM index';
       const { root } = Parser.parse(src);
 
-      const node = commands.set.set(root, 'unmapped_fields', 'LOAD');
+      const node = commands.set.update(root, 'unmapped_fields', 'LOAD');
       const printed = BasicPrettyPrinter.print(root);
       expect(printed).toBe('SET approximation = TRUE; FROM index');
       expect(node).toBeUndefined();
@@ -89,7 +89,7 @@ describe('commands.set', () => {
       const src = 'SET approximation = TRUE; SET unmapped_fields = "DEFAULT"; FROM index';
       const { root } = Parser.parse(src);
 
-      commands.set.set(root, 'unmapped_fields', 'LOAD');
+      commands.set.update(root, 'unmapped_fields', 'LOAD');
       const printed = BasicPrettyPrinter.print(root);
 
       expect(printed).toBe('SET approximation = TRUE; SET unmapped_fields = "LOAD"; FROM index');

--- a/src/ast/mutate/commands/set/index.test.ts
+++ b/src/ast/mutate/commands/set/index.test.ts
@@ -146,4 +146,37 @@ describe('commands.set', () => {
       expect(printed).toBe('SET approximation = TRUE; SET unmapped_fields = "LOAD"; FROM index');
     });
   });
+
+  describe('.remove()', () => {
+    it('removes a SET command by setting name', () => {
+      const src = 'SET unmapped_fields = "DEFAULT"; FROM index';
+      const { root } = Parser.parse(src);
+
+      commands.set.remove(root, 'unmapped_fields');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('FROM index');
+    });
+
+    it('returns undefined when the setting does not exist', () => {
+      const src = 'SET approximation = TRUE; FROM index';
+      const { root } = Parser.parse(src);
+
+      const removed = commands.set.remove(root, 'unmapped_fields');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(removed).toBeUndefined();
+      expect(printed).toBe('SET approximation = TRUE; FROM index');
+    });
+
+    it('only removes the targeted setting when multiple exist', () => {
+      const src = 'SET approximation = TRUE; SET unmapped_fields = "DEFAULT"; FROM index';
+      const { root } = Parser.parse(src);
+
+      commands.set.remove(root, 'unmapped_fields');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET approximation = TRUE; FROM index');
+    });
+  });
 });

--- a/src/ast/mutate/commands/set/index.test.ts
+++ b/src/ast/mutate/commands/set/index.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Parser } from '../../../../parser';
+import { BasicPrettyPrinter } from '../../../../pretty_print';
+import * as commands from '..';
+
+describe('commands.set', () => {
+  describe('.list()', () => {
+    it('lists all SET header commands', () => {
+      const src = 'SET approximation = true; SET unmapped_fields = "DEFAULT"; FROM index';
+      const { root } = Parser.parse(src);
+
+      const nodes = [...commands.set.list(root)];
+
+      expect(nodes).toHaveLength(2);
+    });
+
+    it('returns empty iterator when no SET commands exist', () => {
+      const src = 'FROM index | LIMIT 10';
+      const { root } = Parser.parse(src);
+
+      const nodes = [...commands.set.list(root)];
+
+      expect(nodes).toHaveLength(0);
+    });
+  });
+
+  describe('.findBySettingName()', () => {
+    it('finds a SET command by setting name', () => {
+      const src = 'SET approximation = true; SET unmapped_fields = "DEFAULT"; FROM index';
+      const { root } = Parser.parse(src);
+
+      const node = commands.set.findBySettingName(root, 'unmapped_fields');
+
+      expect(node).toMatchObject({
+        type: 'header-command',
+        name: 'set',
+        args: [
+          {
+            type: 'function',
+            subtype: 'binary-expression',
+            name: '=',
+            args: [
+              { type: 'identifier', name: 'unmapped_fields' },
+              { type: 'literal', literalType: 'keyword', valueUnquoted: 'DEFAULT' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('returns undefined when the setting does not exist', () => {
+      const src = 'SET approximation = true; FROM index';
+      const { root } = Parser.parse(src);
+
+      const node = commands.set.findBySettingName(root, 'unmapped_fields');
+
+      expect(node).toBeUndefined();
+    });
+  });
+
+  describe('.set()', () => {
+    it('modifies the value of an existing setting', () => {
+      const src = 'SET unmapped_fields = "DEFAULT"; FROM index';
+      const { root } = Parser.parse(src);
+
+      commands.set.set(root, 'unmapped_fields', 'LOAD');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET unmapped_fields = "LOAD"; FROM index');
+    });
+
+    it('returns undefined when the setting does not exist', () => {
+      const src = 'SET approximation = TRUE; FROM index';
+      const { root } = Parser.parse(src);
+
+      const node = commands.set.set(root, 'unmapped_fields', 'LOAD');
+      const printed = BasicPrettyPrinter.print(root);
+      expect(printed).toBe('SET approximation = TRUE; FROM index');
+      expect(node).toBeUndefined();
+    });
+
+    it('only modifies the targeted setting when multiple exist', () => {
+      const src = 'SET approximation = TRUE; SET unmapped_fields = "DEFAULT"; FROM index';
+      const { root } = Parser.parse(src);
+
+      commands.set.set(root, 'unmapped_fields', 'LOAD');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET approximation = TRUE; SET unmapped_fields = "LOAD"; FROM index');
+    });
+  });
+
+  describe('.upsert()', () => {
+    it('modifies the value when the setting already exists', () => {
+      const src = 'SET unmapped_fields = "DEFAULT"; FROM index';
+      const { root } = Parser.parse(src);
+
+      const node = commands.set.upsert(root, 'unmapped_fields', 'LOAD');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET unmapped_fields = "LOAD"; FROM index');
+      expect(node).toMatchObject({
+        type: 'header-command',
+        name: 'set',
+      });
+    });
+
+    it('adds a new SET command when the setting does not exist', () => {
+      const src = 'FROM index | LIMIT 10';
+      const { root } = Parser.parse(src);
+
+      const node = commands.set.upsert(root, 'unmapped_fields', 'LOAD');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET unmapped_fields = "LOAD"; FROM index | LIMIT 10');
+      expect(node).toMatchObject({
+        type: 'header-command',
+        name: 'set',
+        args: [
+          {
+            type: 'function',
+            subtype: 'binary-expression',
+            name: '=',
+            args: [
+              { type: 'identifier', name: 'unmapped_fields' },
+              { type: 'literal', literalType: 'keyword', valueUnquoted: 'LOAD' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('appends alongside existing SET commands', () => {
+      const src = 'SET approximation = TRUE; FROM index';
+      const { root } = Parser.parse(src);
+
+      commands.set.upsert(root, 'unmapped_fields', 'LOAD');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET approximation = TRUE; SET unmapped_fields = "LOAD"; FROM index');
+    });
+  });
+});

--- a/src/ast/mutate/commands/set/index.test.ts
+++ b/src/ast/mutate/commands/set/index.test.ts
@@ -69,7 +69,7 @@ describe('commands.set', () => {
       const src = 'SET unmapped_fields = "DEFAULT"; FROM index';
       const { root } = Parser.parse(src);
 
-      commands.set.update(root, 'unmapped_fields', 'LOAD');
+      commands.set.update(root, 'unmapped_fields', '"LOAD"');
       const printed = BasicPrettyPrinter.print(root);
 
       expect(printed).toBe('SET unmapped_fields = "LOAD"; FROM index');
@@ -79,7 +79,7 @@ describe('commands.set', () => {
       const src = 'SET approximation = TRUE; FROM index';
       const { root } = Parser.parse(src);
 
-      const node = commands.set.update(root, 'unmapped_fields', 'LOAD');
+      const node = commands.set.update(root, 'unmapped_fields', '"LOAD"');
       const printed = BasicPrettyPrinter.print(root);
       expect(printed).toBe('SET approximation = TRUE; FROM index');
       expect(node).toBeUndefined();
@@ -89,10 +89,57 @@ describe('commands.set', () => {
       const src = 'SET approximation = TRUE; SET unmapped_fields = "DEFAULT"; FROM index';
       const { root } = Parser.parse(src);
 
-      commands.set.update(root, 'unmapped_fields', 'LOAD');
+      commands.set.update(root, 'unmapped_fields', '"LOAD"');
       const printed = BasicPrettyPrinter.print(root);
 
       expect(printed).toBe('SET approximation = TRUE; SET unmapped_fields = "LOAD"; FROM index');
+    });
+
+    it('modifies the value of an existing setting with a boolean value', () => {
+      const src = 'SET approximation = TRUE; FROM index';
+      const { root } = Parser.parse(src);
+
+      commands.set.update(root, 'approximation', 'FALSE');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET approximation = FALSE; FROM index');
+    });
+
+    it('modifies the value of an existing setting with a MAP value', () => {
+      const src = 'SET approximation = TRUE; FROM index';
+      const { root } = Parser.parse(src);
+
+      const node = commands.set.update(root, 'approximation', '{ "confidence_level": 0.99 }');
+      const printed = BasicPrettyPrinter.print(root);
+
+      expect(printed).toBe('SET approximation = {"confidence_level": 0.99}; FROM index');
+      expect(node).toMatchObject({
+        type: 'header-command',
+        name: 'set',
+        args: [
+          {
+            type: 'function',
+            subtype: 'binary-expression',
+            name: '=',
+            args: [
+              { type: 'identifier', name: 'approximation' },
+              {
+                type: 'map',
+                entries: [
+                  {
+                    key: {
+                      type: 'literal',
+                      literalType: 'keyword',
+                      valueUnquoted: 'confidence_level',
+                    },
+                    value: { type: 'literal', literalType: 'double', value: 0.99 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
     });
   });
 
@@ -101,7 +148,7 @@ describe('commands.set', () => {
       const src = 'SET unmapped_fields = "DEFAULT"; FROM index';
       const { root } = Parser.parse(src);
 
-      const node = commands.set.upsert(root, 'unmapped_fields', 'LOAD');
+      const node = commands.set.upsert(root, 'unmapped_fields', '"LOAD"');
       const printed = BasicPrettyPrinter.print(root);
 
       expect(printed).toBe('SET unmapped_fields = "LOAD"; FROM index');
@@ -115,7 +162,7 @@ describe('commands.set', () => {
       const src = 'FROM index | LIMIT 10';
       const { root } = Parser.parse(src);
 
-      const node = commands.set.upsert(root, 'unmapped_fields', 'LOAD');
+      const node = commands.set.upsert(root, 'unmapped_fields', '"LOAD"');
       const printed = BasicPrettyPrinter.print(root);
 
       expect(printed).toBe('SET unmapped_fields = "LOAD"; FROM index | LIMIT 10');
@@ -140,7 +187,7 @@ describe('commands.set', () => {
       const src = 'SET approximation = TRUE; FROM index';
       const { root } = Parser.parse(src);
 
-      commands.set.upsert(root, 'unmapped_fields', 'LOAD');
+      commands.set.upsert(root, 'unmapped_fields', '"LOAD"');
       const printed = BasicPrettyPrinter.print(root);
 
       expect(printed).toBe('SET approximation = TRUE; SET unmapped_fields = "LOAD"; FROM index');

--- a/src/ast/mutate/commands/set/index.ts
+++ b/src/ast/mutate/commands/set/index.ts
@@ -64,7 +64,7 @@ export const findBySettingName = (
  * @param value The new string value for the setting.
  * @returns The modified SET header command, or undefined if not found.
  */
-export const set = (
+export const update = (
   ast: ESQLAstQueryExpression,
   settingName: string,
   value: string
@@ -93,7 +93,7 @@ export const upsert = (
   settingName: string,
   value: string
 ): ESQLAstSetHeaderCommand => {
-  const existing = set(ast, settingName, value);
+  const existing = update(ast, settingName, value);
   if (existing) return existing;
 
   const identifier = Builder.identifier(settingName);

--- a/src/ast/mutate/commands/set/index.ts
+++ b/src/ast/mutate/commands/set/index.ts
@@ -62,7 +62,11 @@ export const findBySettingName = (
  *
  * @param ast The root AST node.
  * @param settingName The name of the setting to modify.
- * @param value The new string value for the setting.
+ * @param value The new value, parsed as an ES|QL expression. For example:
+ *   - `'"LOAD"'` → string literal `"LOAD"`
+ *   - `'true'` → boolean literal `TRUE`
+ *   - `'42'` → integer literal `42`
+ *   - `'{ "key": "value" }'` → map expression
  * @returns The modified SET header command, or undefined if not found.
  */
 export const update = (
@@ -88,7 +92,11 @@ export const update = (
  *
  * @param ast The root AST node.
  * @param settingName The name of the setting (e.g. "unmapped_fields").
- * @param value The string value for the setting.
+ * @param value The new value, parsed as an ES|QL expression. For example:
+ *   - `'"LOAD"'` → string literal `"LOAD"`
+ *   - `'true'` → boolean literal `TRUE`
+ *   - `'42'` → integer literal `42`
+ *   - `'{ "key": "value" }'` → map expression
  * @returns The modified or newly created SET header command.
  */
 export const upsert = (

--- a/src/ast/mutate/commands/set/index.ts
+++ b/src/ast/mutate/commands/set/index.ts
@@ -83,7 +83,8 @@ export const update = (
 
 /**
  * Updates the value of an existing SET setting, or inserts a new SET header
- * command if the setting does not exist.
+ * command if the setting does not exist. The new command is inserted as the last
+ * command in the header.
  *
  * @param ast The root AST node.
  * @param settingName The name of the setting (e.g. "unmapped_fields").

--- a/src/ast/mutate/commands/set/index.ts
+++ b/src/ast/mutate/commands/set/index.ts
@@ -7,6 +7,7 @@
 
 import { Builder } from '../../../builder';
 import { isAssignment } from '../../../is';
+import { Parser } from '../../../../parser';
 import type {
   ESQLAstQueryExpression,
   ESQLAstSetHeaderCommand,
@@ -14,7 +15,6 @@ import type {
   BinaryExpressionAssignmentOperator,
   ESQLIdentifier,
 } from '../../../../types';
-import { synth } from '../../../../composer';
 
 /**
  * Lists all SET header commands in the query AST.
@@ -73,10 +73,10 @@ export const update = (
   const cmd = findBySettingName(ast, settingName);
   if (!cmd) return undefined;
 
-  const newValueNode = synth.exp(value);
+  const newNode = Parser.parseExpression(value).root;
 
   const assignment = cmd.args[0] as ESQLBinaryExpression<BinaryExpressionAssignmentOperator>;
-  assignment.args[1] = newValueNode;
+  assignment.args[1] = newNode;
 
   return cmd;
 };
@@ -100,8 +100,8 @@ export const upsert = (
   if (existing) return existing;
 
   const identifier = Builder.identifier(settingName);
-  const newValueNode = synth.exp(value);
-  const assignment = Builder.expression.func.binary('=', [identifier, newValueNode]);
+  const newNode = Parser.parseExpression(value).root;
+  const assignment = Builder.expression.func.binary('=', [identifier, newNode]);
   const cmd = Builder.header.command.set([
     assignment as ESQLBinaryExpression<BinaryExpressionAssignmentOperator>,
   ]);

--- a/src/ast/mutate/commands/set/index.ts
+++ b/src/ast/mutate/commands/set/index.ts
@@ -14,6 +14,7 @@ import type {
   BinaryExpressionAssignmentOperator,
   ESQLIdentifier,
 } from '../../../../types';
+import { synth } from '../../../../composer';
 
 /**
  * Lists all SET header commands in the query AST.
@@ -72,9 +73,10 @@ export const update = (
   const cmd = findBySettingName(ast, settingName);
   if (!cmd) return undefined;
 
+  const newValueNode = synth.exp(value);
+
   const assignment = cmd.args[0] as ESQLBinaryExpression<BinaryExpressionAssignmentOperator>;
-  const newValue = Builder.expression.literal.string(value);
-  assignment.args[1] = newValue;
+  assignment.args[1] = newValueNode;
 
   return cmd;
 };
@@ -97,8 +99,8 @@ export const upsert = (
   if (existing) return existing;
 
   const identifier = Builder.identifier(settingName);
-  const literal = Builder.expression.literal.string(value);
-  const assignment = Builder.expression.func.binary('=', [identifier, literal]);
+  const newValueNode = synth.exp(value);
+  const assignment = Builder.expression.func.binary('=', [identifier, newValueNode]);
   const cmd = Builder.header.command.set([
     assignment as ESQLBinaryExpression<BinaryExpressionAssignmentOperator>,
   ]);

--- a/src/ast/mutate/commands/set/index.ts
+++ b/src/ast/mutate/commands/set/index.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Builder } from '../../../builder';
+import { isAssignment } from '../../../is';
+import type {
+  ESQLAstQueryExpression,
+  ESQLAstSetHeaderCommand,
+  ESQLBinaryExpression,
+  BinaryExpressionAssignmentOperator,
+  ESQLSingleAstItem,
+} from '../../../../types';
+
+/**
+ * Lists all SET header commands in the query AST.
+ *
+ * @param ast The root AST node.
+ * @returns An iterable of SET header commands.
+ */
+export const list = function* (
+  ast: ESQLAstQueryExpression
+): IterableIterator<ESQLAstSetHeaderCommand> {
+  if (!ast.header) return;
+  for (const cmd of ast.header) {
+    if (cmd.name === 'set') {
+      yield cmd as ESQLAstSetHeaderCommand;
+    }
+  }
+};
+
+/**
+ * Finds a SET header command by its setting name.
+ *
+ * @param ast The root AST node.
+ * @param settingName The name of the setting to find (e.g. "unmapped_fields").
+ * @returns The matching SET header command, or undefined.
+ */
+export const findBySettingName = (
+  ast: ESQLAstQueryExpression,
+  settingName: string
+): ESQLAstSetHeaderCommand | undefined => {
+  for (const cmd of list(ast)) {
+    const assignment = cmd.args[0];
+    if (isAssignment(assignment)) {
+      const identifier = assignment.args[0] as ESQLSingleAstItem;
+      if (identifier.name === settingName) {
+        return cmd;
+      }
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Updates the value of an existing SET setting. Returns the modified header
+ * command, or `undefined` if no matching setting was found.
+ *
+ * @param ast The root AST node.
+ * @param settingName The name of the setting to modify.
+ * @param value The new string value for the setting.
+ * @returns The modified SET header command, or undefined if not found.
+ */
+export const set = (
+  ast: ESQLAstQueryExpression,
+  settingName: string,
+  value: string
+): ESQLAstSetHeaderCommand | undefined => {
+  const cmd = findBySettingName(ast, settingName);
+  if (!cmd) return undefined;
+
+  const assignment = cmd.args[0] as ESQLBinaryExpression<BinaryExpressionAssignmentOperator>;
+  const newValue = Builder.expression.literal.string(value);
+  assignment.args[1] = newValue;
+
+  return cmd;
+};
+
+/**
+ * Updates the value of an existing SET setting, or inserts a new SET header
+ * command if the setting does not exist.
+ *
+ * @param ast The root AST node.
+ * @param settingName The name of the setting (e.g. "unmapped_fields").
+ * @param value The string value for the setting.
+ * @returns The modified or newly created SET header command.
+ */
+export const upsert = (
+  ast: ESQLAstQueryExpression,
+  settingName: string,
+  value: string
+): ESQLAstSetHeaderCommand => {
+  const existing = set(ast, settingName, value);
+  if (existing) return existing;
+
+  const identifier = Builder.identifier(settingName);
+  const literal = Builder.expression.literal.string(value);
+  const assignment = Builder.expression.func.binary('=', [identifier, literal]);
+  const cmd = Builder.header.command.set([
+    assignment as ESQLBinaryExpression<BinaryExpressionAssignmentOperator>,
+  ]);
+
+  if (!ast.header) {
+    ast.header = [];
+  }
+  ast.header.push(cmd);
+
+  return cmd;
+};

--- a/src/ast/mutate/commands/set/index.ts
+++ b/src/ast/mutate/commands/set/index.ts
@@ -12,7 +12,7 @@ import type {
   ESQLAstSetHeaderCommand,
   ESQLBinaryExpression,
   BinaryExpressionAssignmentOperator,
-  ESQLSingleAstItem,
+  ESQLIdentifier,
 } from '../../../../types';
 
 /**
@@ -46,7 +46,7 @@ export const findBySettingName = (
   for (const cmd of list(ast)) {
     const assignment = cmd.args[0];
     if (isAssignment(assignment)) {
-      const identifier = assignment.args[0] as ESQLSingleAstItem;
+      const identifier = assignment.args[0] as ESQLIdentifier;
       if (identifier.name === settingName) {
         return cmd;
       }
@@ -108,5 +108,26 @@ export const upsert = (
   }
   ast.header.push(cmd);
 
+  return cmd;
+};
+
+/**
+ * Removes a SET header command by its setting name.
+ *
+ * @param ast The root AST node.
+ * @param settingName The name of the setting to remove.
+ * @returns The removed SET header command, or undefined if not found.
+ */
+export const remove = (
+  ast: ESQLAstQueryExpression,
+  settingName: string
+): ESQLAstSetHeaderCommand | undefined => {
+  const cmd = findBySettingName(ast, settingName);
+  if (!cmd || !ast.header) return;
+
+  const index = ast.header.indexOf(cmd);
+  if (index === -1) return;
+
+  ast.header.splice(index, 1);
   return cmd;
 };


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/250172
## Summary
This PR adds mutation helpers to safely add or modify query settings.

## Details
The following methods were added:
 * `.set`
    - `.list()` &mdash; List all `SET` header commands.
    - `.findBySettingName()` &mdash; Find a `SET` command by its setting name.
    - `.set()` &mdash; Modify the value of an existing `SET` setting.
    - `.upsert()` &mdash; Modify a `SET` setting value, or add a new `SET` command if it does not exist.

The one needed for this task is `.upsert()` but as it needs the rest to be built they were also exposed.
This is a similar implementation to `LIMIT` and `FROM` commands.

### Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Unit tests have been added or updated.
- [x] The proper documentation has been added or updated.
- [ ] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax.
- [x] The PR title has the correct [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) label in the title, this is crucial for the correct versioning of this package. Check the following cheat shit.
  | Title Label | Release |
  |---|---|
  | `breaking: true (!)` | `major` |
  | `feat` | `minor` |
  | `fix` | `patch` |
  | `refactor` | `patch` |
  | `perf` | `patch` |
  | `build` | `patch` |
  | `docs`  | `patch` |
  | `chore` | `patch` |
  | `revert` | `patch` |

(Built with the help of Cursor)
