### PR TITLE
build: New renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,6 @@
   "timezone": "Etc/UTC",
   "schedule": ["* * * * 1"],
   "minimumReleaseAge": "14 days",
-  "nvm": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "description": "TypeScript compiler",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,79 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>elastic/renovate-config"]
+  "extends": ["local>elastic/renovate-config"],
+  "timezone": "Etc/UTC",
+  "schedule": ["* * * * 1"],
+  "minimumReleaseAge": "14 days",
+  "nvm": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "TypeScript compiler",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "typescript",
+      "groupSlug": "typescript"
+    },
+    {
+      "description": "Node.js version",
+      "matchManagers": ["nvm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "node",
+      "groupSlug": "node"
+    },
+    {
+      "description": "@types/node",
+      "matchPackageNames": ["@types/node"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "node",
+      "groupSlug": "node"
+    },
+    {
+      "description": "React and Storybook",
+      "matchPackagePatterns": [
+        "^react$",
+        "^react-dom$",
+        "^@types/react$",
+        "^@types/react-dom$",
+        "^storybook$",
+        "^@storybook/",
+        "^eslint-plugin-storybook$"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "react-storybook",
+      "groupSlug": "react-storybook"
+    },
+    {
+      "description": "Production dependencies",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dependencies",
+      "groupSlug": "dependencies"
+    },
+    {
+      "description": "Rest: Build, lint, release, and test tooling",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["typescript"],
+      "excludePackagePatterns": [
+        "^react$",
+        "^react-dom$",
+        "^@types/react$",
+        "^@types/react-dom$",
+        "^storybook$",
+        "^@storybook/",
+        "^eslint-plugin-storybook$",
+        "^@types/node$"
+      ],
+      "groupName": "build-lint-test",
+      "groupSlug": "build-lint-test"
+    },
+    {
+      "description": "Major updates: one PR per package",
+      "matchUpdateTypes": ["major"],
+      "groupName": "{{{depName}}}",
+      "groupSlug": "{{{depNameSanitized}}}"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
This PR changes Renovate configuration to create less PR's.

## Details
* It will only run on Mondays. During that day it can create several PR's.
* It will batch minor (and fixes) updates in the following groups:
  - Production dependencies
  - React and storybook related packages
  - Rest of dev dependencies (Testing/Lint/Build/Format/etc)
* It will create dedicated PR's for:
  - Typescript updates.
  - Node updates.
  - Major updates on any package.

Lets test if it works correctly here and then apply it to our other packages.