### PR TITLE
feat: Add lexer rewind helper for IN subquery

### DIFF
--- a/src/parser/antlr/lexer_config.js
+++ b/src/parser/antlr/lexer_config.js
@@ -22,6 +22,12 @@ export default class lexer_config extends Lexer {
     return true;
   }
 
+  rewindToTokenStart(charsToKeep) {
+    this._input.seek(this._tokenStartCharIndex + charsToKeep);
+    this.line = this._tokenStartLine;
+    this.column = this._tokenStartColumn + charsToKeep;
+  }
+
   // PromQL parenthesis depth tracking for nested parentheses in PromQL queries
   incPromqlDepth() {
     this._promqlDepth++;

--- a/src/parser/antlr/smoketest.test.ts
+++ b/src/parser/antlr/smoketest.test.ts
@@ -17,6 +17,25 @@ describe('ES|QL Lexer/Parser', () => {
     expect(symbolicNames).toEqual(['FROM', 'FROM_WS', 'UNQUOTED_SOURCE', undefined]);
   });
 
+  it('should rewind to the current token start keeping a token prefix', () => {
+    const lexer = new ESQLLexer(new CharStream('(FROM logs)')) as ESQLLexer & {
+      rewindToTokenStart(charsToKeep: number): void;
+    };
+
+    lexer._tokenStartCharIndex = 0;
+    lexer._tokenStartLine = 1;
+    lexer._tokenStartColumn = 0;
+    lexer._input.seek(6);
+    lexer.line = 1;
+    lexer.column = 6;
+
+    lexer.rewindToTokenStart(1);
+
+    expect(lexer._input.index).toBe(1);
+    expect(lexer.line).toBe(1);
+    expect(lexer.column).toBe(1);
+  });
+
   it('should match token numbers between lexer and parser', () => {
     expect(ESQLLexer.FROM).toEqual(ESQLParser.FROM);
     expect(ESQLLexer.RENAME).toEqual(ESQLParser.RENAME);


### PR DESCRIPTION
## Summary

Add a small lexer helper to rewind the input stream back to the current token start 

This is needed for upcoming `IN` subquery lexer support, where the lexer needs to inspect the token after `IN (` and then re-lex the subquery normally.