### PR TITLE
feat: PromQL comment collection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "build": "tsup && tsc",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "build:watch": "tsup --watch --onSuccess \"tsc\"",
     "prebuild:antlr4": "brew bundle --file=./.buildkite/scripts/antlr4_tools/brewfile",
     "build:antlr4": "npm run build:antlr4:esql && npm run build:antlr4:promql",

--- a/src/embedded_languages/promql/ast/__tests__/find_node.test.ts
+++ b/src/embedded_languages/promql/ast/__tests__/find_node.test.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PromQLParser } from '../../parser/parser';
+import { findNodeAtOrAfter, findNodeAtOrBefore } from '../find_node';
+
+const parse = (src: string) => PromQLParser.parse(src).root;
+
+describe('findNodeAtOrAfter', () => {
+  describe('plain selector', () => {
+    const ast = parse('up');
+
+    it('returns the deepest node at the start of the source', () => {
+      const node = findNodeAtOrAfter(ast, 0);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('up');
+    });
+
+    it('returns the deepest node containing pos', () => {
+      const node = findNodeAtOrAfter(ast, 1);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('up');
+    });
+
+    it('returns null when pos is past the end of the tree', () => {
+      expect(findNodeAtOrAfter(ast, 2)).toBeNull();
+      expect(findNodeAtOrAfter(ast, 100)).toBeNull();
+    });
+  });
+
+  describe('binary expression', () => {
+    const ast = parse('a + b');
+
+    it('finds left operand when pos is on left', () => {
+      const node = findNodeAtOrAfter(ast, 0);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('a');
+    });
+
+    it('finds right operand selector when pos is between operands', () => {
+      const node = findNodeAtOrAfter(ast, 2);
+
+      expect(node?.type).toBe('selector');
+      expect(node?.name).toBe('b');
+    });
+
+    it('finds right operand selector when pos is right before it', () => {
+      const node = findNodeAtOrAfter(ast, 3);
+
+      expect(node?.type).toBe('selector');
+      expect(node?.name).toBe('b');
+    });
+
+    it('descends to identifier b at its exact position', () => {
+      const node = findNodeAtOrAfter(ast, 4);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('b');
+    });
+
+    it('returns null past the end', () => {
+      expect(findNodeAtOrAfter(ast, 5)).toBeNull();
+    });
+  });
+
+  describe('nested function call', () => {
+    const ast = parse('rate(x[5m])');
+
+    it('descends to the deepest node containing pos', () => {
+      const node = findNodeAtOrAfter(ast, 5);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('x');
+    });
+
+    it('finds the duration literal', () => {
+      const node = findNodeAtOrAfter(ast, 7);
+
+      expect(node?.type).toBe('literal');
+      expect(node?.name).toBe('5m');
+    });
+
+    it('returns the outermost child selector when pos is at function start', () => {
+      const node = findNodeAtOrAfter(ast, 0);
+
+      expect(node?.type).toBe('selector');
+      expect(node?.name).toBe('x');
+    });
+  });
+
+  describe('parens', () => {
+    const ast = parse('(a + b)');
+
+    it('descends through parens to find a', () => {
+      const node = findNodeAtOrAfter(ast, 1);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('a');
+    });
+
+    it('descends through parens to find b', () => {
+      const node = findNodeAtOrAfter(ast, 5);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('b');
+    });
+  });
+});
+
+describe('findNodeAtOrBefore', () => {
+  describe('plain selector', () => {
+    const ast = parse('up');
+
+    it('returns the deepest node at the end of the source', () => {
+      const node = findNodeAtOrBefore(ast, 1);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('up');
+    });
+
+    it('returns the outermost preceding node when pos is past the end', () => {
+      const node = findNodeAtOrBefore(ast, 5);
+
+      expect(node?.type).toBe('selector');
+      expect(node?.name).toBe('up');
+    });
+
+    it('returns null when pos is before the start of the tree', () => {
+      expect(findNodeAtOrBefore(ast, -1)).toBeNull();
+    });
+  });
+
+  describe('binary expression', () => {
+    const ast = parse('a + b');
+
+    it('finds left operand when pos is on left', () => {
+      const node = findNodeAtOrBefore(ast, 0);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('a');
+    });
+
+    it('finds left operand selector when pos is between operands', () => {
+      const node = findNodeAtOrBefore(ast, 2);
+
+      expect(node?.type).toBe('selector');
+      expect(node?.name).toBe('a');
+    });
+
+    it('finds left operand selector when pos is right before right operand', () => {
+      const node = findNodeAtOrBefore(ast, 3);
+
+      expect(node?.type).toBe('selector');
+      expect(node?.name).toBe('a');
+    });
+
+    it('descends to identifier b when pos is on it', () => {
+      const node = findNodeAtOrBefore(ast, 4);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('b');
+    });
+
+    it('returns the binary expression when pos is past every child', () => {
+      const node = findNodeAtOrBefore(ast, 10);
+
+      expect(node?.type).toBe('binary-expression');
+    });
+  });
+
+  describe('nested function call', () => {
+    const ast = parse('rate(x[5m])');
+
+    it('descends to ident x at its position', () => {
+      const node = findNodeAtOrBefore(ast, 5);
+
+      expect(node?.type).toBe('identifier');
+      expect(node?.name).toBe('x');
+    });
+
+    it('descends to literal 5m', () => {
+      const node = findNodeAtOrBefore(ast, 8);
+
+      expect(node?.type).toBe('literal');
+      expect(node?.name).toBe('5m');
+    });
+
+    it('returns the function when pos is past the function end', () => {
+      const node = findNodeAtOrBefore(ast, 11);
+
+      expect(node?.type).toBe('function');
+      expect(node?.name).toBe('rate');
+    });
+  });
+
+  describe('offset', () => {
+    const ast = parse('a offset 5m');
+
+    it('finds the deep offset duration literal', () => {
+      const node = findNodeAtOrBefore(ast, 10);
+
+      expect(node?.type).toBe('literal');
+      expect(node?.name).toBe('5m');
+    });
+  });
+});

--- a/src/embedded_languages/promql/ast/find_node.ts
+++ b/src/embedded_languages/promql/ast/find_node.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PromQLAstNode, PromQLAstQueryExpression } from '../types';
+import { childrenOfPromqlNode } from './traversal';
+
+/**
+ * Extra fool-proofing to make sure the nodes are always sorted by their location.
+ */
+const sortedLocatedChildren = (node: PromQLAstNode): PromQLAstNode[] => {
+  const children: PromQLAstNode[] = [];
+
+  for (const child of childrenOfPromqlNode(node)) {
+    if (child.location) children.push(child);
+  }
+
+  children.sort((a, b) => a.location.min - b.location.min);
+
+  return children;
+};
+
+const findForward = (node: PromQLAstNode, pos: number): PromQLAstNode | null => {
+  for (const child of sortedLocatedChildren(node)) {
+    const { min, max } = child.location;
+
+    if (min <= pos && max >= pos) {
+      return findForward(child, pos) ?? child;
+    }
+
+    if (min > pos) {
+      return child;
+    }
+  }
+
+  return null;
+};
+
+const findBackward = (node: PromQLAstNode, pos: number): PromQLAstNode | null => {
+  const children = sortedLocatedChildren(node);
+
+  for (let i = children.length - 1; i >= 0; i--) {
+    const child = children[i];
+    const { min, max } = child.location;
+
+    if (min <= pos && max >= pos) {
+      return findBackward(child, pos) ?? child;
+    }
+
+    if (max < pos) {
+      return child;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Finds the deepest PromQL AST node at or after the given character position.
+ *
+ * - If `pos` falls inside a node, descends into that node looking for the most
+ * specific descendant containing `pos`.
+ * - If no node contains `pos`, returns the first node whose `location.min` is
+ * greater than `pos`.
+ * - Returns `null` if no such node exists (i.e. `pos` is past the end of the
+ * tree).
+ */
+export const findNodeAtOrAfter = (
+  ast: PromQLAstQueryExpression,
+  pos: number
+): PromQLAstNode | null => findForward(ast, pos);
+
+/**
+ * Finds the deepest PromQL AST node at or before the given character position.
+ *
+ * - If `pos` falls inside a node, descends into that node looking for the most
+ * specific descendant containing `pos`.
+ * - If no node contains `pos`, returns the last node whose `location.max` is
+ * less than `pos`.
+ * - Returns `null` if no such node exists (i.e. `pos` is before the start of
+ * the tree).
+ */
+export const findNodeAtOrBefore = (
+  ast: PromQLAstQueryExpression,
+  pos: number
+): PromQLAstNode | null => findBackward(ast, pos);

--- a/src/embedded_languages/promql/ast/traversal.ts
+++ b/src/embedded_languages/promql/ast/traversal.ts
@@ -21,10 +21,13 @@ export function* childrenOfPromqlNode(node: PromQLAstNode): Iterable<PromQLAstNo
       return;
     }
     case 'function': {
-      if (node.grouping) {
+      if (node.grouping && node.groupingPosition !== 'after') {
         yield node.grouping;
       }
       yield* node.args;
+      if (node.grouping && node.groupingPosition === 'after') {
+        yield node.grouping;
+      }
       return;
     }
     case 'selector': {
@@ -35,6 +38,49 @@ export function* childrenOfPromqlNode(node: PromQLAstNode): Iterable<PromQLAstNo
       const { labelName, value } = node;
       if (labelName) yield labelName;
       if (value) yield value;
+      return;
+    }
+    case 'binary-expression': {
+      yield node.left;
+      if (node.modifier) yield node.modifier;
+      yield node.right;
+      return;
+    }
+    case 'unary-expression': {
+      yield node.arg;
+      return;
+    }
+    case 'subquery': {
+      yield node.expr;
+      yield node.range;
+      if (node.resolution) yield node.resolution;
+      if (node.evaluation) yield node.evaluation;
+      return;
+    }
+    case 'parens': {
+      if (node.child) yield node.child;
+      return;
+    }
+    case 'evaluation': {
+      if (node.offset) yield node.offset;
+      if (node.at) yield node.at;
+      return;
+    }
+    case 'offset': {
+      if (node.duration) yield node.duration;
+      return;
+    }
+    case 'at': {
+      if (typeof node.value !== 'string') yield node.value;
+      return;
+    }
+    case 'modifier': {
+      yield* node.labels;
+      if (node.groupModifier) yield node.groupModifier;
+      return;
+    }
+    case 'group-modifier': {
+      yield* node.labels;
       return;
     }
   }

--- a/src/embedded_languages/promql/parser/__tests__/decorations.test.ts
+++ b/src/embedded_languages/promql/parser/__tests__/decorations.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CharStreams, CommonTokenStream } from 'antlr4';
+import { default as PromQLLexer } from '../../../../parser/antlr/promql_lexer';
+import { attachPromQLDecorations, collectPromQLDecorations } from '../decorations';
+import { PromQLParser } from '../parser';
+import type { PromQLFunction, PromQLSelector } from '../../types';
+
+/**
+ * Helper: lex the source text and fill the token stream so that
+ * `collectPromQLDecorations` can iterate over all tokens.
+ */
+const tokenize = (src: string): CommonTokenStream => {
+  const lexer = new PromQLLexer(CharStreams.fromString(src));
+  const tokens = new CommonTokenStream(lexer);
+  tokens.fill();
+  return tokens;
+};
+
+describe('collectPromQLDecorations', () => {
+  describe('no comments', () => {
+    it('returns empty list for plain expression', () => {
+      const result = collectPromQLDecorations(tokenize('rate(http_requests_total[5m])'));
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns empty list for empty input', () => {
+      const result = collectPromQLDecorations(tokenize(''));
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('whole-line comments (no content to left)', () => {
+    it('collects a single whole-line comment', () => {
+      const result = collectPromQLDecorations(tokenize('# hello world\n'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.subtype).toBe('single-line');
+      expect(result[0].node.text).toBe(' hello world');
+      expect(result[0].hasContentToLeft).toBe(false);
+    });
+
+    it('collects comment without trailing newline (EOF)', () => {
+      const result = collectPromQLDecorations(tokenize('# end of file'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.text).toBe(' end of file');
+      expect(result[0].hasContentToLeft).toBe(false);
+    });
+
+    it('collects comment before an expression', () => {
+      const result = collectPromQLDecorations(tokenize('# the rate\nrate(x[5m])'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.text).toBe(' the rate');
+      expect(result[0].hasContentToLeft).toBe(false);
+    });
+
+    it('collects multiple whole-line comments', () => {
+      const src = '# line one\n# line two\nup';
+      const result = collectPromQLDecorations(tokenize(src));
+
+      expect(result).toHaveLength(2);
+      expect(result[0].node.text).toBe(' line one');
+      expect(result[0].hasContentToLeft).toBe(false);
+      expect(result[1].node.text).toBe(' line two');
+      expect(result[1].hasContentToLeft).toBe(false);
+    });
+  });
+
+  describe('trailing comments (content to left)', () => {
+    it('collects a trailing comment after an expression', () => {
+      const result = collectPromQLDecorations(tokenize('up # is it up?\n'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.text).toBe(' is it up?');
+      expect(result[0].hasContentToLeft).toBe(true);
+    });
+
+    it('collects trailing comment after complex expression', () => {
+      const result = collectPromQLDecorations(
+        tokenize('rate(http_requests_total[5m]) # request rate\n')
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.text).toBe(' request rate');
+      expect(result[0].hasContentToLeft).toBe(true);
+    });
+
+    it('trailing comment without trailing newline (EOF)', () => {
+      const result = collectPromQLDecorations(tokenize('up # trailing'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.text).toBe(' trailing');
+      expect(result[0].hasContentToLeft).toBe(true);
+    });
+  });
+
+  describe('mixed comments', () => {
+    it('collects trailing + whole-line comments', () => {
+      const src = 'up # trailing\n# whole line\ndown';
+      const result = collectPromQLDecorations(tokenize(src));
+
+      expect(result).toHaveLength(2);
+      expect(result[0].node.text).toBe(' trailing');
+      expect(result[0].hasContentToLeft).toBe(true);
+      expect(result[1].node.text).toBe(' whole line');
+      expect(result[1].hasContentToLeft).toBe(false);
+    });
+
+    it('collects whole-line + trailing comments', () => {
+      const src = '# header\nup # inline\n';
+      const result = collectPromQLDecorations(tokenize(src));
+
+      expect(result).toHaveLength(2);
+      expect(result[0].node.text).toBe(' header');
+      expect(result[0].hasContentToLeft).toBe(false);
+      expect(result[1].node.text).toBe(' inline');
+      expect(result[1].hasContentToLeft).toBe(true);
+    });
+
+    it('handles multiple lines with mixed comments', () => {
+      const src = [
+        '# top comment',
+        'rate(x[5m]) # rate comment',
+        '# middle comment',
+        'sum(y) # sum comment',
+      ].join('\n');
+      const result = collectPromQLDecorations(tokenize(src));
+
+      expect(result).toHaveLength(4);
+
+      expect(result[0].node.text).toBe(' top comment');
+      expect(result[0].hasContentToLeft).toBe(false);
+
+      expect(result[1].node.text).toBe(' rate comment');
+      expect(result[1].hasContentToLeft).toBe(true);
+
+      expect(result[2].node.text).toBe(' middle comment');
+      expect(result[2].hasContentToLeft).toBe(false);
+
+      expect(result[3].node.text).toBe(' sum comment');
+      expect(result[3].hasContentToLeft).toBe(true);
+    });
+  });
+
+  describe('location tracking', () => {
+    it('tracks location of a simple comment', () => {
+      const result = collectPromQLDecorations(tokenize('# hi\n'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.location).toEqual({ min: 0, max: 3 });
+    });
+
+    it('tracks location of a trailing comment', () => {
+      const result = collectPromQLDecorations(tokenize('up # x\n'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.location).toEqual({ min: 3, max: 5 });
+    });
+
+    it('applies offset to locations', () => {
+      const result = collectPromQLDecorations(tokenize('# hi\n'), 100);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.location).toEqual({ min: 100, max: 103 });
+    });
+
+    it('comment at EOF without newline has correct location', () => {
+      const result = collectPromQLDecorations(tokenize('up # end'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.location).toEqual({ min: 3, max: 7 });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('empty comment', () => {
+      const result = collectPromQLDecorations(tokenize('#\n'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.text).toBe('');
+      expect(result[0].hasContentToLeft).toBe(false);
+    });
+
+    it('comment with only spaces', () => {
+      const result = collectPromQLDecorations(tokenize('#   \n'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].node.text).toBe('   ');
+    });
+
+    it('punctuation-only tokens do not set hasContentToLeft', () => {
+      // Though unusual, a comment right after `(` should not have content to left
+      // since `(` is punctuation, and there's no identifier before it.
+      // This is more of a theoretical edge case.
+      const result = collectPromQLDecorations(tokenize('(# inside\n)'));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].hasContentToLeft).toBe(false);
+    });
+  });
+});
+
+describe('attachPromQLDecorations', () => {
+  const parseAndAttach = (src: string) => {
+    const lexer = new PromQLLexer(CharStreams.fromString(src));
+    const tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    const comments = collectPromQLDecorations(tokens);
+
+    const { root } = PromQLParser.parse(src);
+    attachPromQLDecorations(root, comments);
+
+    return root;
+  };
+
+  describe('trailing comments', () => {
+    it('attaches a trailing comment as rightSingleLine on the outermost expression', () => {
+      const root = parseAndAttach('up # is it up?');
+      const selector = root.expression as PromQLSelector;
+
+      expect(selector.formatting?.rightSingleLine?.text).toBe(' is it up?');
+    });
+
+    it('attaches a trailing comment after a function call onto the function', () => {
+      const root = parseAndAttach('rate(x[5m]) # request rate');
+      const fn = root.expression as PromQLFunction;
+
+      expect(fn.formatting?.rightSingleLine?.text).toBe(' request rate');
+    });
+  });
+
+  describe('whole-line comments', () => {
+    it('attaches a whole-line comment as top on the following expression', () => {
+      const root = parseAndAttach('# header\nup');
+      const selector = root.expression as PromQLSelector;
+
+      expect(selector.formatting?.top?.[0]?.text).toBe(' header');
+    });
+
+    it('accumulates multiple consecutive whole-line comments', () => {
+      const root = parseAndAttach('# one\n# two\nup');
+      const selector = root.expression as PromQLSelector;
+
+      expect(selector.formatting?.top).toHaveLength(2);
+      expect(selector.formatting?.top?.[0]?.text).toBe(' one');
+      expect(selector.formatting?.top?.[1]?.text).toBe(' two');
+    });
+
+    it('attaches a trailing whole-line comment as bottom on the root', () => {
+      const root = parseAndAttach('up\n# trailing whole line');
+
+      expect(root.formatting?.bottom?.[0]?.text).toBe(' trailing whole line');
+    });
+  });
+
+  describe('mixed comments', () => {
+    it('handles top + trailing + bottom together', () => {
+      const root = parseAndAttach('# top\nup # inline\n# bottom');
+      const selector = root.expression as PromQLSelector;
+
+      expect(selector.formatting?.top?.[0]?.text).toBe(' top');
+      expect(selector.formatting?.rightSingleLine?.text).toBe(' inline');
+      expect(root.formatting?.bottom?.[0]?.text).toBe(' bottom');
+    });
+  });
+});
+
+describe('PromQLParser.parse withFormatting', () => {
+  it('does not attach comments by default', () => {
+    const { root } = PromQLParser.parse('# header\nup # trailing');
+    const selector = root.expression as PromQLSelector;
+
+    expect(selector.formatting).toBeUndefined();
+    expect(root.formatting).toBeUndefined();
+  });
+
+  it('attaches comments when withFormatting is true', () => {
+    const { root } = PromQLParser.parse('# header\nup # trailing', { withFormatting: true });
+    const selector = root.expression as PromQLSelector;
+
+    expect(selector.formatting?.top?.[0]?.text).toBe(' header');
+    expect(selector.formatting?.rightSingleLine?.text).toBe(' trailing');
+  });
+
+  it('respects the offset option when attaching comments', () => {
+    const { root } = PromQLParser.parse('# header\nup', { withFormatting: true, offset: 100 });
+    const selector = root.expression as PromQLSelector;
+    const comment = selector.formatting?.top?.[0];
+
+    expect(comment?.text).toBe(' header');
+    expect(comment?.location).toEqual({ min: 100, max: 107 });
+  });
+});

--- a/src/embedded_languages/promql/parser/__tests__/selector.test.ts
+++ b/src/embedded_languages/promql/parser/__tests__/selector.test.ts
@@ -248,7 +248,9 @@ selector 0-33 "http_requests_total"
       expect('\n' + tree).toBe(`
 selector 0-28 "http_requests_total"
 ├─ identifier 0-18 "http_requests_total"
-└─ evaluation 20-28 "evaluation"`);
+└─ evaluation 20-28 "evaluation"
+   └─ offset 20-28 "offset"
+      └─ literal 27-28 "5m"`);
     });
   });
 });

--- a/src/embedded_languages/promql/parser/decorations.ts
+++ b/src/embedded_languages/promql/parser/decorations.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type CommonTokenStream } from 'antlr4';
+import { Builder } from '../../../ast/builder';
+import { findNodeAtOrAfter, findNodeAtOrBefore } from '../ast/find_node';
+import type { ESQLAstCommentSingleLine, ESQLAstNodeFormatting } from '../../../types';
+import type { PromQLAstNode, PromQLAstQueryExpression } from '../types';
+
+/**
+ * ANTLR hidden channel number. Comments and whitespace are placed on this
+ * channel by the lexer.
+ */
+const HIDDEN_CHANNEL = 1;
+
+/**
+ * Punctuation characters that don't count as "content" for the purposes of
+ * determining whether a comment has content to its left.
+ */
+const punctuationChars = new Set(['.', ',', ';', ':', '(', ')', '[', ']', '{', '}']);
+
+const isLikelyPunctuation = (text: string): boolean =>
+  text.length === 1 && punctuationChars.has(text);
+
+/**
+ * A collected comment decoration with its positional context.
+ */
+export interface PromQLCommentDecoration {
+  type: 'comment';
+
+  /**
+   * Whether there is non-punctuation content to the left of this comment on
+   * the same line. When `true`, the comment is a trailing comment (e.g.
+   * `rate(x[5m]) # trailing`). When `false`, the comment occupies its own
+   * line (e.g. `# whole-line comment`).
+   */
+  hasContentToLeft: boolean;
+
+  /** The AST comment node. */
+  node: ESQLAstCommentSingleLine;
+}
+
+/**
+ * Strip the `#` prefix and any trailing `\r?\n` from a PromQL comment token.
+ */
+const cleanCommentText = (text: string): string => {
+  let end = text.length;
+
+  if (text[end - 1] === '\n') {
+    end--;
+  }
+  if (end > 0 && text[end - 1] === '\r') {
+    end--;
+  }
+
+  return text.slice(1, end);
+};
+
+/**
+ * Collects all comments from the PromQL token stream.
+ *
+ * Iterates through every token (including hidden-channel tokens) and extracts
+ * comment decorations with their positional context.
+ *
+ * @param tokens ANTLR token stream from the PromQL lexer.
+ * @param offset Character offset to add to all locations (for embedded PromQL).
+ * @returns List of comment decorations in source order.
+ */
+export const collectPromQLDecorations = (
+  tokens: CommonTokenStream,
+  offset: number = 0
+): PromQLCommentDecoration[] => {
+  const result: PromQLCommentDecoration[] = [];
+  const list = tokens.tokens;
+  const length = list.length;
+
+  let pos = 0;
+  let hasContentToLeft = false;
+
+  // The last token is <EOF>, which we skip.
+  for (let i = 0; i < length - 1; i++) {
+    const token = list[i];
+    const { channel, text } = token;
+    const min = pos;
+    const max = min + text.length - 1; // max is inclusive, like in ES|QL AST
+
+    pos = max + 1;
+
+    if (channel !== HIDDEN_CHANNEL) {
+      if (!isLikelyPunctuation(text)) {
+        hasContentToLeft = true;
+      }
+      continue;
+    }
+
+    // Hidden channel token — check if it's a comment (starts with `#`)
+    if (text[0] !== '#') {
+      // Whitespace token — check for line breaks to reset context
+      if (text.indexOf('\n') !== -1) {
+        hasContentToLeft = false;
+      }
+      continue;
+    }
+
+    const cleanText = cleanCommentText(text);
+    // TODO: Do we need this check after cleaning? Should cleaning remove all line breaks?
+    const endsWithNewline = text[text.length - 1] === '\n';
+    const maxOffset = endsWithNewline ? (text[text.length - 2] === '\r' ? 2 : 1) : 0;
+    const node = Builder.comment('single-line', cleanText, {
+      min: min + offset,
+      max: max - maxOffset + offset,
+    });
+
+    result.push({
+      type: 'comment',
+      hasContentToLeft,
+      node,
+    });
+
+    if (endsWithNewline) {
+      hasContentToLeft = false;
+    }
+  }
+
+  return result;
+};
+
+const ensureFormatting = (node: PromQLAstNode): ESQLAstNodeFormatting => {
+  if (!node.formatting) {
+    node.formatting = {};
+  }
+
+  return node.formatting;
+};
+
+const attachTopComment = (node: PromQLAstNode, comment: ESQLAstCommentSingleLine): void => {
+  const formatting = ensureFormatting(node);
+  if (!formatting.top) formatting.top = [];
+  formatting.top.push(comment);
+};
+
+const attachBottomComment = (node: PromQLAstNode, comment: ESQLAstCommentSingleLine): void => {
+  const formatting = ensureFormatting(node);
+  if (!formatting.bottom) formatting.bottom = [];
+  formatting.bottom.push(comment);
+};
+
+const attachTrailingComment = (node: PromQLAstNode, comment: ESQLAstCommentSingleLine): void => {
+  const formatting = ensureFormatting(node);
+  formatting.rightSingleLine = comment;
+};
+
+/**
+ * Attaches the comments collected by {@link collectPromQLDecorations} to the
+ * appropriate nodes in the PromQL AST. Similar attachment logic is used as
+ * in ES|QL.
+ *
+ * @param ast Root of the PromQL AST.
+ * @param comments Decorations collected from the token stream.
+ */
+export const attachPromQLDecorations = (
+  ast: PromQLAstQueryExpression,
+  comments: PromQLCommentDecoration[]
+): void => {
+  for (const comment of comments) {
+    const { location } = comment.node;
+
+    if (!location) continue;
+
+    if (!comment.hasContentToLeft) {
+      const target = findNodeAtOrAfter(ast, location.max);
+
+      if (target) {
+        attachTopComment(target, comment.node);
+      } else {
+        attachBottomComment(ast, comment.node);
+      }
+      continue;
+    }
+
+    const target = findNodeAtOrBefore(ast, location.min);
+
+    if (target) {
+      attachTrailingComment(target, comment.node);
+    }
+  }
+};

--- a/src/embedded_languages/promql/parser/parser.ts
+++ b/src/embedded_languages/promql/parser/parser.ts
@@ -11,6 +11,7 @@ import { default as PromQLParserGenerated } from '../../../parser/antlr/promql_p
 import { PromQLErrorListener } from './promql_error_listener';
 import { PromQLCstToAstConverter } from './cst_to_ast_converter';
 import { PromQLBuilder } from '../ast/builder';
+import { attachPromQLDecorations, collectPromQLDecorations } from './decorations';
 import type { PromQLAstQueryExpression, PromQLParseResult } from '../types';
 import type { EditorError } from '../../../types';
 
@@ -21,6 +22,13 @@ export interface PromQLParseOptions {
    * The offset will be added to all location values in the AST.
    */
   offset?: number;
+
+  /**
+   * When `true`, comments are collected from the token stream and attached to
+   * AST nodes via the `formatting` property. Required for the pretty-printer
+   * to round-trip comments. Defaults to `false`.
+   */
+  withFormatting?: boolean;
 }
 
 /**
@@ -101,6 +109,12 @@ export class PromQLParser {
           root: PromQLBuilder.expression.query(undefined, { incomplete: true }),
           errors: this.errors.getErrors(),
         };
+      }
+
+      if (this.options.withFormatting) {
+        this.tokens.fill();
+        const comments = collectPromQLDecorations(this.tokens, this.options.offset ?? 0);
+        attachPromQLDecorations(root, comments);
       }
 
       return {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "lib", "README.md", "src/stories", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,8 @@
     "target": "ES2022",
     // Include ES2022 standard library types
     "lib": ["ES2022"],
+    // Explicit ambient types — jest globals (describe/it/expect) and Node built-ins.
+    "types": ["jest", "node"],
     // Preserve comments in compiled output
     "removeComments": false,
     // Allow JS files so TypeScript can infer types from .js config files (e.g. lexer_config.js)
@@ -43,5 +45,5 @@
     "rootDir": "./src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "lib", "README.md", "**/*.test.ts", "src/stories"]
+  "exclude": ["node_modules", "lib", "README.md", "src/stories"]
 }


### PR DESCRIPTION
## Summary

PromQL comment collection from parser hidden stream, so that we have them in the AST and can pretty-print them back to the user. Otherwise the parser just discards them.

Assigns the comment to the deepest node at that position, but also takes into account surrounding punctuation. Similar to ES|QL comment collection and assignment, but simpler as PromQL only has single line comments.


### Checklist

- [x] Unit tests have been added or updated.
- [x] The proper documentation has been added or updated.
- [x] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax.
- [x] The PR title has the correct [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) label in the title, this is crucial for the correct versioning of this package. Check the following cheat shit.
  | Title Label | Release |
  |---|---|
  | `breaking: true (!)` | `major` |
  | `feat` | `minor` |
  | `fix` | `patch` |
  | `refactor` | `patch` |
  | `perf` | `patch` |
  | `build` | `patch` |
  | `docs`  | `patch` |
  | `chore` | `patch` |
  | `revert` | `patch` |
