### PR TITLE
feat: add PromQL to Composer

### DIFF
--- a/src/composer/__tests__/esql.promql.test.ts
+++ b/src/composer/__tests__/esql.promql.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { esql } from '../esql';
+import { pqlFunc, pqlSel, pqlNum } from '../synth';
+
+test('simple instant vector', () => {
+  const query = esql.promql(pqlSel('up'));
+
+  expect(query.print()).toBe('PROMQL (up)');
+});
+
+test('range vector selector', () => {
+  const query = esql.promql(pqlSel('http_requests_total', '5m'));
+
+  expect(query.print()).toBe('PROMQL (http_requests_total[5m])');
+});
+
+test('from PromQL synth-created node', () => {
+  const query = esql.promql(esql.pql`http_requests_total[5m]`);
+
+  expect(query.print()).toBe('PROMQL (http_requests_total[5m])');
+});
+
+test('from PromQL synth-created node - 2', () => {
+  const query = esql.promql(esql.pql`http_requests_total[5m]`, { params: { a: 'b' } });
+
+  expect(query.print()).toBe('PROMQL a = b (http_requests_total[5m])');
+});
+
+test('from PromQL synth-created node - 3', () => {
+  const query = esql.promql(esql.pql`http_requests_total[5m]`, {
+    params: { a: 'b' },
+    outputName: 'result',
+  });
+
+  expect(query.print()).toBe('PROMQL a = b result = (http_requests_total[5m])');
+});
+
+test('function expression', () => {
+  const query = esql.promql(pqlFunc('rate', pqlSel('http_requests_total', '5m')));
+
+  expect(query.print()).toBe('PROMQL (rate(http_requests_total[5m]))');
+});
+
+test('aggregation with grouping', () => {
+  const expr = pqlFunc('sum', pqlFunc('rate', pqlSel('metric', '5m')), { by: ['job'] });
+  const query = esql.promql(expr);
+
+  expect(query.print()).toBe('PROMQL (sum(rate(metric[5m])) by (job))');
+});
+
+test('accepts a raw PromQL string', () => {
+  const query = esql.promql('rate(http_requests_total[5m])');
+
+  expect(query.print()).toBe('PROMQL (rate(http_requests_total[5m]))');
+});
+
+test('accepts a simple metric string', () => {
+  const query = esql.promql('up');
+
+  expect(query.print()).toBe('PROMQL (up)');
+});
+
+test('accepts a pql-tagged expression', () => {
+  const expr = esql.pql`sum(rate(metric[5m])) by (job)`;
+  const query = esql.promql(expr);
+
+  expect(query.print()).toBe('PROMQL (sum(rate(metric[5m])) by (job))');
+});
+
+test('single command-level param', () => {
+  const query = esql.promql(pqlSel('up'), { params: { index: 'k8s' } });
+
+  expect(query.print()).toBe('PROMQL index = k8s (up)');
+});
+
+test('multiple command-level params', () => {
+  const query = esql.promql(pqlSel('up'), { params: { index: 'k8s', timeout: '10s' } });
+
+  expect(query.print()).toBe('PROMQL index = k8s timeout = 10s (up)');
+});
+
+test('named output column', () => {
+  const query = esql.promql(pqlFunc('sum', pqlSel('metric', '5m')), { outputName: 'result' });
+
+  expect(query.print()).toBe('PROMQL result = (sum(metric[5m]))');
+});
+
+test('params and output name together', () => {
+  const query = esql.promql(pqlSel('up'), {
+    params: { index: 'k8s' },
+    outputName: 'health',
+  });
+
+  expect(query.print()).toBe('PROMQL index = k8s health = (up)');
+});
+
+test('result is a ComposerQuery that can be piped', () => {
+  const query = esql.promql(pqlSel('up')).limit(100);
+
+  expect(query.print()).toBe('PROMQL (up) | LIMIT 100');
+});
+
+test('result can be sorted', () => {
+  const query = esql.promql(pqlFunc('rate', pqlSel('metric', '5m')))
+    .where`value > ${pqlNum(0)}`.limit(50);
+
+  expect(query.print()).toBe('PROMQL (rate(metric[5m])) | WHERE value > 0 | LIMIT 50');
+});
+
+test('first command is a PROMQL command', () => {
+  const query = esql.promql(pqlSel('up'));
+  const [cmd] = query.ast.commands;
+
+  expect(cmd.type).toBe('command');
+  expect(cmd.name).toBe('promql');
+});

--- a/src/composer/esql.ts
+++ b/src/composer/esql.ts
@@ -19,6 +19,8 @@ import type {
   FromSourcesAndMetadataQueryStarter,
   FromSourcesQueryStarter,
   ParametrizedComposerQueryTag,
+  PromqlQueryStarter,
+  PromqlStarterOpts,
 } from './types';
 import type { ESQLSource } from '../types';
 import { isSource } from '../ast/is';
@@ -177,6 +179,28 @@ const createFromSourceAndMetadataCommandStarter =
       : esql`${synth.kwd(cmd)} ${sourceNodes}`;
   };
 
+const createPromqlStarter = (): PromqlQueryStarter => (expression, opts?: PromqlStarterOpts) => {
+  const expr = typeof expression === 'string' ? synth.pql(expression) : expression;
+
+  const paramsPart = opts?.params
+    ? Object.entries(opts.params)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(' ')
+    : '';
+
+  const outputName = opts?.outputName;
+
+  if (paramsPart && outputName) {
+    return esql`PROMQL ${synth.kwd(paramsPart)} ${synth.col(outputName)} = (${expr as synth.SynthTemplateHole})`;
+  } else if (paramsPart) {
+    return esql`PROMQL ${synth.kwd(paramsPart)} (${expr as synth.SynthTemplateHole})`;
+  } else if (outputName) {
+    return esql`PROMQL ${synth.col(outputName)} = (${expr as synth.SynthTemplateHole})`;
+  } else {
+    return esql`PROMQL (${expr as synth.SynthTemplateHole})`;
+  }
+};
+
 /**
  * ESQL query composer tag function.
  *
@@ -228,6 +252,8 @@ export const esql: ComposerQueryTag &
     from: createFromLikeStarter('FROM'),
 
     ts: createFromLikeStarter('TS'),
+
+    promql: createPromqlStarter(),
 
     get nop() {
       return synth.cmd`WHERE TRUE`;

--- a/src/composer/index.ts
+++ b/src/composer/index.ts
@@ -11,6 +11,6 @@ export { ComposerQuery } from './composer_query';
 export { ParameterHole } from './parameter_hole';
 
 export * as synth from './synth';
-export { qry, cmd, exp } from './synth';
+export { qry, cmd, exp, pql } from './synth';
 
 export { EsqlQuery } from './query';

--- a/src/composer/synth/__tests__/promql.test.ts
+++ b/src/composer/synth/__tests__/promql.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BasicPrettyPrinter } from '../../../pretty_print';
+import { PromQLBasicPrettyPrinter } from '../../../embedded_languages/promql/pretty_print';
+import { pql, promqlExpression } from '../promql';
+import { cmd } from '../command';
+import { qry } from '../query';
+
+test('creates a PromQL expression node from a tagged template', () => {
+  const node = pql`rate(http_requests_total[5m])`;
+
+  expect(node).toBeDefined();
+  expect(node.type).toBe('query');
+  expect(node.dialect).toBe('promql');
+});
+
+test('pql is an alias for promqlExpression', () => {
+  expect(pql).toBe(promqlExpression);
+});
+
+test('serializes a PromQL expression back to text', () => {
+  const node = pql`rate(http_requests_total[5m])`;
+  const text = PromQLBasicPrettyPrinter.print(node);
+
+  expect(text).toBe('rate(http_requests_total[5m])');
+});
+
+test('serializes a metric selector', () => {
+  const node = pql`http_requests_total{job="api",status="200"}`;
+  const text = PromQLBasicPrettyPrinter.print(node);
+
+  expect(text).toBe('http_requests_total{job="api", status="200"}');
+});
+
+test('can be used as a function call', () => {
+  const node = pql('up == 1');
+  const text = PromQLBasicPrettyPrinter.print(node);
+
+  expect(text).toBe('up == 1');
+});
+
+test('can compose PromQL expressions', () => {
+  const time = pql`5m`;
+  const selector = pql`some_metric{job="api"}[${time}]`;
+  const number = pql`456`;
+  const func = pql`func(${selector}, 123, ${number})`;
+  const text = func + '';
+
+  expect(text).toBe('func(some_metric{job="api"}[5m], 123, 456)');
+});
+
+test('can be interpolated as a hole in a PROMQL command', () => {
+  const expr = pql`bytes_in{job="prometheus"}`;
+  const node = cmd`PROMQL (${expr})`;
+  const text = BasicPrettyPrinter.command(node);
+
+  expect(text).toBe('PROMQL (bytes_in{job="prometheus"})');
+});
+
+test('can build a full PROMQL query via qry', () => {
+  const expr = pql`rate(http_requests_total[5m])`;
+  const node = qry`PROMQL (${expr})`;
+  const text = BasicPrettyPrinter.print(node);
+
+  expect(text).toBe('PROMQL (rate(http_requests_total[5m]))');
+});
+
+test('trims whitespace from source', () => {
+  const node = pql`  up  `;
+  const text = PromQLBasicPrettyPrinter.print(node);
+
+  expect(text).toBe('up');
+});

--- a/src/composer/synth/__tests__/promql_nodes.test.ts
+++ b/src/composer/synth/__tests__/promql_nodes.test.ts
@@ -1,0 +1,310 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PromQLBasicPrettyPrinter } from '../../../embedded_languages/promql/pretty_print';
+import { BasicPrettyPrinter } from '../../../pretty_print';
+import {
+  pqlAt,
+  pqlBinary,
+  pqlFunc,
+  pqlLabel,
+  pqlLabels,
+  pqlNum,
+  pqlOffset,
+  pqlParens,
+  pqlSel,
+  pqlStr,
+  pqlSubquery,
+  pqlTime,
+  pqlUnary,
+} from '../promql_nodes';
+import { cmd } from '../command';
+import { qry } from '../query';
+
+const print = (node: Parameters<typeof PromQLBasicPrettyPrinter.print>[0]) =>
+  PromQLBasicPrettyPrinter.print(node);
+
+describe('pqlTime', () => {
+  test('simple duration', () => expect(pqlTime('5m') + '').toBe('5m'));
+  test('compound duration', () => expect(pqlTime('1h30m') + '').toBe('1h30m'));
+  test('toString()', () => expect(pqlTime('10s') + '').toBe('10s'));
+});
+
+describe('pqlNum', () => {
+  test('integer', () => expect(pqlNum(42) + '').toBe('42'));
+  test('negative integer', () => expect(pqlNum(-7) + '').toBe('-7'));
+  test('decimal', () => expect(pqlNum(3.14) + '').toBe('3.14'));
+  test('whole decimal keeps .0', () => expect(pqlNum(5.0) + '').toBe('5'));
+  test('toString() integer', () => expect(pqlNum(1) + '').toBe('1'));
+});
+
+describe('pqlStr', () => {
+  test('simple string', () => expect(pqlStr('hello') + '').toBe('"hello"'));
+  test('string with special chars', () => expect(pqlStr('a\nb') + '').toBe('"a\\nb"'));
+  test('toString()', () => expect(pqlStr('ok') + '').toBe('"ok"'));
+});
+
+describe('pqlLabel', () => {
+  test('equality match', () => {
+    const label = pqlLabel('job', '=', 'api');
+
+    expect(label.type).toBe('label');
+    expect(label.name).toBe('job');
+    expect(label.operator).toBe('=');
+  });
+
+  test('regex match', () => {
+    const label = pqlLabel('status', '=~', '2..');
+    expect(label.operator).toBe('=~');
+    expect(label + '').toBe('status=~"2.."');
+  });
+
+  test('no value', () => {
+    const label = pqlLabel('env', '!=');
+    expect(label.value).toBeUndefined();
+  });
+});
+
+describe('pqlLabels', () => {
+  test('object shorthand', () => {
+    const lm = pqlLabels({ job: 'api', env: 'prod' });
+
+    expect(print(pqlSel('m', lm.args))).toBe('m{job="api", env="prod"}');
+  });
+
+  test('explicit label array', () => {
+    const lm = pqlLabels([pqlLabel('s', '=~', '2..')]);
+
+    expect(lm.type).toBe('label-map');
+    expect(lm.args).toHaveLength(1);
+  });
+
+  test('toString()', () => {
+    const lm = pqlLabels({ x: 'y' });
+
+    expect(lm.type).toBe('label-map');
+    expect(lm + '').toBe('{x="y"}');
+  });
+});
+
+describe('pqlSel', () => {
+  test('metric only', () => {
+    expect(pqlSel('http_requests_total') + '').toBe('http_requests_total');
+  });
+
+  test('no metric (undefined)', () => expect(pqlSel() + '').toBe(''));
+
+  test('range vector', () => expect(pqlSel('up', '5m') + '').toBe('up[5m]'));
+
+  test('with label object', () =>
+    expect(pqlSel('metric', { job: 'api' }) + '').toBe('metric{job="api"}'));
+
+  test('with label object and range', () =>
+    expect(pqlSel('metric', { job: 'api' }, '5m') + '').toBe('metric{job="api"}[5m]'));
+
+  test('with explicit label array', () =>
+    expect(pqlSel('metric', [pqlLabel('s', '=~', '2..')]) + '').toBe('metric{s=~"2.."}'));
+
+  test('label-only selector (no metric)', () =>
+    expect(pqlSel(undefined, { job: 'api' }) + '').toBe('{job="api"}'));
+
+  test('multiple labels', () =>
+    expect(pqlSel('m', { a: '1', b: '2' }) + '').toBe('m{a="1", b="2"}'));
+
+  test('toString()', () => expect(String(pqlSel('bytes_in', '1m'))).toBe('bytes_in[1m]'));
+});
+
+describe('pqlFunc', () => {
+  test('single arg', () => expect(pqlFunc('abs', pqlSel('metric')) + '').toBe('abs(metric)'));
+
+  test('no args', () => expect(pqlFunc('time', []) + '').toBe('time()'));
+
+  test('rate with range vector', () =>
+    expect(pqlFunc('rate', pqlSel('http_requests_total', '5m')) + '').toBe(
+      'rate(http_requests_total[5m])'
+    ));
+
+  test('multiple args (array)', () =>
+    expect(pqlFunc('histogram_quantile', [pqlNum(0.95), pqlSel('le', '5m')]) + '').toBe(
+      'histogram_quantile(0.95, le[5m])'
+    ));
+
+  test('aggregation with by (after, default)', () =>
+    expect(pqlFunc('sum', pqlSel('metric'), { by: ['job'] }) + '').toBe('sum(metric) by (job)'));
+
+  test('aggregation with by (before)', () =>
+    expect(pqlFunc('sum', pqlSel('metric'), { by: ['job'], groupingPosition: 'before' }) + '').toBe(
+      'sum by (job) (metric)'
+    ));
+
+  test('aggregation with without', () =>
+    expect(pqlFunc('avg', pqlSel('metric'), { without: ['instance'] }) + '').toBe(
+      'avg(metric) without (instance)'
+    ));
+
+  test('toString()', () => expect(String(pqlFunc('rate', pqlSel('m', '1m')))).toBe('rate(m[1m])'));
+});
+
+describe('pqlBinary', () => {
+  const a = pqlSel('a');
+  const b = pqlSel('b');
+
+  test('arithmetic +', () => expect(pqlBinary('+', a, b) + '').toBe('a + b'));
+
+  test('arithmetic -', () => expect(pqlBinary('-', a, b) + '').toBe('a - b'));
+
+  test('arithmetic *', () => expect(pqlBinary('*', a, b) + '').toBe('a * b'));
+
+  test('arithmetic /', () => expect(pqlBinary('/', a, b) + '').toBe('a / b'));
+
+  test('comparison >', () => expect(pqlBinary('>', a, b) + '').toBe('a > b'));
+
+  test('comparison with bool', () =>
+    expect(pqlBinary('>', a, b, { bool: true }) + '').toBe('a > bool b'));
+
+  test('set operator and', () => expect(pqlBinary('and', a, b) + '').toBe('a and b'));
+
+  test('set operator or', () => expect(pqlBinary('or', a, b) + '').toBe('a or b'));
+
+  test('vector matching on', () =>
+    expect(pqlBinary('/', a, b, { on: ['job'] }) + '').toBe('a / on(job) b'));
+
+  test('vector matching ignoring', () =>
+    expect(pqlBinary('/', a, b, { ignoring: ['instance'] }) + '').toBe('a / ignoring(instance) b'));
+
+  test('vector matching with group_left', () =>
+    expect(pqlBinary('*', a, b, { on: ['job'], groupLeft: [] }) + '').toBe(
+      'a * on(job) group_left b'
+    ));
+
+  test('vector matching with group_right and labels', () =>
+    expect(pqlBinary('*', a, b, { on: ['dc'], groupRight: ['env'] }) + '').toBe(
+      'a * on(dc) group_right(env) b'
+    ));
+
+  test('toString()', () => expect(String(pqlBinary('+', a, b))).toBe('a + b'));
+});
+
+describe('pqlUnary', () => {
+  test('negate', () => expect(pqlUnary('-', pqlSel('metric')) + '').toBe('-metric'));
+
+  test('positive', () => expect(pqlUnary('+', pqlSel('metric')) + '').toBe('+metric'));
+});
+
+describe('pqlParens', () => {
+  test('wraps expression', () => expect(pqlParens(pqlSel('metric')) + '').toBe('(metric)'));
+
+  test('nested parens', () => expect(pqlParens(pqlParens(pqlSel('m'))) + '').toBe('((m))'));
+});
+
+describe('pqlSubquery', () => {
+  test('without resolution', () =>
+    expect(pqlSubquery(pqlSel('metric'), '30m') + '').toBe('metric[30m:]'));
+
+  test('with resolution', () =>
+    expect(pqlSubquery(pqlSel('metric'), '30m', '5m') + '').toBe('metric[30m:5m]'));
+
+  test('function inside subquery', () =>
+    expect(pqlSubquery(pqlFunc('rate', pqlSel('m', '5m')), '1h') + '').toBe('rate(m[5m])[1h:]'));
+});
+
+describe('pqlOffset', () => {
+  test('positive offset', () => {
+    const o = pqlOffset('5m');
+
+    expect(o.type).toBe('offset');
+    expect(o.negative).toBe(false);
+    expect(o + '').toBe('offset 5m');
+  });
+
+  test('negative offset', () => {
+    const o = pqlOffset('5m', true);
+
+    expect(o.negative).toBe(true);
+  });
+});
+
+describe('pqlAt', () => {
+  test('start()', () => {
+    const a = pqlAt('start()');
+
+    expect(a.type).toBe('at');
+    expect(a.value).toBe('start()');
+  });
+
+  test('end()', () => {
+    const a = pqlAt('end()');
+
+    expect(a.value).toBe('end()');
+    expect(a.type).toBe('at');
+  });
+
+  test('timestamp', () => {
+    const a = pqlAt('1609459200');
+
+    expect(a.type).toBe('at');
+    expect((a.value as { value: string }).value).toBe('1609459200');
+  });
+
+  test('negative', () => {
+    const a = pqlAt('1234567890', true);
+
+    expect(a.negative).toBe(true);
+  });
+});
+
+describe('composition', () => {
+  test('rate of labelled range vector', () =>
+    expect(print(pqlFunc('rate', pqlSel('http_requests_total', { job: 'api' }, '5m')))).toBe(
+      'rate(http_requests_total{job="api"}[5m])'
+    ));
+
+  test('sum of rate by job', () =>
+    expect(
+      print(pqlFunc('sum', pqlFunc('rate', pqlSel('http_requests_total', '5m')), { by: ['job'] }))
+    ).toBe('sum(rate(http_requests_total[5m])) by (job)'));
+
+  test('error ratio binary expression', () => {
+    const errors = pqlFunc('rate', pqlSel('errors_total', '5m'));
+    const total = pqlFunc('rate', pqlSel('requests_total', '5m'));
+
+    expect(print(pqlBinary('/', errors, total))).toBe(
+      'rate(errors_total[5m]) / rate(requests_total[5m])'
+    );
+  });
+});
+
+describe('hole interpolation in ES|QL synth templates', () => {
+  test('pqlSel as PROMQL command hole', () => {
+    const sel = pqlSel('bytes_in', { job: 'prometheus' });
+    const node = cmd`PROMQL (${sel})`;
+
+    expect(BasicPrettyPrinter.command(node)).toBe('PROMQL (bytes_in{job="prometheus"})');
+  });
+
+  test('pqlFunc as PROMQL command hole', () => {
+    const expr = pqlFunc('rate', pqlSel('http_requests_total', '5m'));
+    const node = cmd`PROMQL (${expr})`;
+
+    expect(BasicPrettyPrinter.command(node)).toBe('PROMQL (rate(http_requests_total[5m]))');
+  });
+
+  test('pqlBinary as PROMQL command hole', () => {
+    const a = pqlSel('errors_total');
+    const b = pqlSel('requests_total');
+    const node = cmd`PROMQL (${pqlBinary('/', a, b)})`;
+
+    expect(BasicPrettyPrinter.command(node)).toBe('PROMQL (errors_total / requests_total)');
+  });
+
+  test('pqlSel in full ES|QL query', () => {
+    const expr = pqlFunc('sum', pqlSel('metric', '5m'), { by: ['job'] });
+    const node = qry`PROMQL (${expr})`;
+
+    expect(BasicPrettyPrinter.print(node)).toBe('PROMQL (sum(metric[5m]) by (job))');
+  });
+});

--- a/src/composer/synth/holes.ts
+++ b/src/composer/synth/holes.ts
@@ -7,6 +7,7 @@
 
 import { Builder } from '../../ast/builder';
 import { BasicPrettyPrinter, LeafPrinter } from '../../pretty_print';
+import { PromQLBasicPrettyPrinter } from '../../embedded_languages/promql/pretty_print';
 import { isProperNode } from '../../ast/is';
 import { SynthNode } from './synth_node';
 import { SynthLiteralFragment } from './synth_literal_fragment';
@@ -15,6 +16,7 @@ import type {
   SynthQualifiedColumnShorthand,
   SynthTemplateHole,
 } from './types';
+import type { PromQLAstExpression } from '../../embedded_languages/promql/types';
 
 class UnexpectedSynthHoleError extends Error {
   constructor(hole: unknown) {
@@ -107,8 +109,10 @@ export const holeToFragment = (hole: SynthTemplateHole): string => {
         }
 
         return list;
-      } else if (hole instanceof SynthNode || isProperNode(hole)) {
-        return BasicPrettyPrinter.print(hole);
+      } else if ((hole as unknown as { dialect?: string }).dialect === 'promql') {
+        return PromQLBasicPrettyPrinter.print(hole as unknown as PromQLAstExpression);
+      } else if (hole instanceof SynthNode || isProperNode(hole as unknown)) {
+        return BasicPrettyPrinter.print(hole as Parameters<typeof BasicPrettyPrinter.print>[0]);
       }
 
       throw new UnexpectedSynthHoleError(hole);

--- a/src/composer/synth/index.ts
+++ b/src/composer/synth/index.ts
@@ -10,4 +10,6 @@ export { exp, expression } from './expression';
 export { cmd, command } from './command';
 export { qry, query } from './query';
 export { hdr, header } from './header';
+export { pql, promqlExpression } from './promql';
 export * from './nodes';
+export * from './promql_nodes';

--- a/src/composer/synth/promql.ts
+++ b/src/composer/synth/promql.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ParseOptions } from '../../parser';
+import { PromQLParser } from '../../embedded_languages/promql/parser';
+import type { PromQLAstQueryExpression } from '../../embedded_languages/promql/types';
+import { createTag } from './tag';
+import type { SynthGenerator } from './types';
+import { SynthNode } from './synth_node';
+
+const generator: SynthGenerator<PromQLAstQueryExpression> = (
+  src: string,
+  { withFormatting = true }: ParseOptions = {}
+): PromQLAstQueryExpression => {
+  const { root } = PromQLParser.parse(src.trim(), { withFormatting });
+
+  return SynthNode.from(root);
+};
+
+export const promqlExpression = createTag<PromQLAstQueryExpression>(generator);
+
+/**
+ * Short 3-letter alias for DX convenience.
+ */
+export const pql = promqlExpression;

--- a/src/composer/synth/promql_nodes.ts
+++ b/src/composer/synth/promql_nodes.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PromQLBuilder } from '../../embedded_languages/promql/ast/builder';
+import type {
+  PromQLAstExpression,
+  PromQLAt,
+  PromQLBinaryExpression,
+  PromQLBinaryOperator,
+  PromQLFunction,
+  PromQLLabel,
+  PromQLLabelMap,
+  PromQLLabelMatchOperator,
+  PromQLNumericLiteral,
+  PromQLOffset,
+  PromQLParens,
+  PromQLSelector,
+  PromQLStringLiteral,
+  PromQLSubquery,
+  PromQLTimeValue,
+  PromQLUnaryExpression,
+} from '../../embedded_languages/promql/types';
+import { SynthNode } from './synth_node';
+
+/**
+ * Creates a PromQL time-duration literal.
+ */
+export const pqlTime = (value: string): PromQLTimeValue =>
+  SynthNode.from(PromQLBuilder.expression.literal.time(value));
+
+/**
+ * Creates a PromQL numeric literal.
+ */
+export const pqlNum = (value: number): PromQLNumericLiteral =>
+  SynthNode.from(
+    Number.isInteger(value)
+      ? PromQLBuilder.expression.literal.integer(value)
+      : PromQLBuilder.expression.literal.decimal(value)
+  );
+
+/**
+ * Creates a PromQL string literal.
+ */
+export const pqlStr = (value: string): PromQLStringLiteral =>
+  SynthNode.from(PromQLBuilder.expression.literal.string(value));
+
+/**
+ * Creates a single PromQL label matcher.
+ *
+ * ```ts
+ * pqlLabel("job", "=", "api")     // job="api"
+ * pqlLabel("status", "=~", "2..") // status=~"2.."
+ * pqlLabel("env", "!=", "dev")    // env!="dev"
+ * ```
+ */
+export const pqlLabel = (name: string, op: PromQLLabelMatchOperator, value?: string): PromQLLabel =>
+  SynthNode.from(
+    PromQLBuilder.label(
+      PromQLBuilder.identifier(name),
+      op,
+      value !== undefined ? PromQLBuilder.expression.literal.string(value) : undefined
+    )
+  );
+
+/**
+ * Supported input forms for label arguments used by `pqlLabels` and `pqlSel`:
+ *
+ * - a plain object whose values are equality-matched strings: `{ job: "api" }`
+ * - an explicit array of `PromQLLabel` nodes from `pqlLabel()`
+ */
+export type PqlLabelArg = Record<string, string> | PromQLLabel[];
+
+const normLabels = (input: PqlLabelArg): PromQLLabel[] => {
+  if (Array.isArray(input)) return input;
+
+  return Object.entries(input).map(([name, value]) =>
+    PromQLBuilder.label(
+      PromQLBuilder.identifier(name),
+      '=',
+      PromQLBuilder.expression.literal.string(value)
+    )
+  );
+};
+
+/**
+ * Creates a PromQL label map.
+ *
+ * ```ts
+ * pqlLabels({ job: "api", env: "prod" })       // {job="api", env="prod"}
+ * pqlLabels([pqlLabel("status", "=~", "2..")]) // {status=~"2.."}
+ * ```
+ */
+export const pqlLabels = (input: PqlLabelArg): PromQLLabelMap =>
+  SynthNode.from(PromQLBuilder.labelMap(normLabels(input)));
+
+/**
+ * Creates a PromQL instant or range vector selector.
+ *
+ * Overloads (second argument determines form):
+ *
+ * ```ts
+ * pqlSel("metric")                             // metric
+ * pqlSel("metric", "5m")                       // metric[5m]
+ * pqlSel("metric", { job: "api" })             // metric{job="api"}
+ * pqlSel("metric", { job: "api" }, "5m")       // metric{job="api"}[5m]
+ * pqlSel(undefined, { job: "api" })            // {job="api"}
+ * pqlSel("metric", [pqlLabel("s","=~","2..")]) // metric{s=~"2.."}
+ * ```
+ */
+export function pqlSel(metric?: string): PromQLSelector;
+export function pqlSel(metric: string | undefined, range: string): PromQLSelector;
+export function pqlSel(metric: string | undefined, labels: PqlLabelArg): PromQLSelector;
+export function pqlSel(
+  metric: string | undefined,
+  labels: PqlLabelArg,
+  range: string
+): PromQLSelector;
+export function pqlSel(
+  metric?: string,
+  labelsOrRange?: PqlLabelArg | string,
+  range?: string
+): PromQLSelector {
+  const metricNode = metric !== undefined ? PromQLBuilder.identifier(metric) : undefined;
+
+  let labelMap: PromQLLabelMap | undefined;
+  let duration: PromQLTimeValue | undefined;
+
+  if (typeof labelsOrRange === 'string') {
+    duration = PromQLBuilder.expression.literal.time(labelsOrRange);
+  } else if (labelsOrRange !== undefined) {
+    labelMap = PromQLBuilder.labelMap(normLabels(labelsOrRange));
+    if (range !== undefined) {
+      duration = PromQLBuilder.expression.literal.time(range);
+    }
+  }
+
+  return SynthNode.from(
+    PromQLBuilder.expression.selector.node({ metric: metricNode, labelMap, duration })
+  );
+}
+
+/**
+ * Options for `pqlFunc`.
+ */
+export interface PqlFuncOpts {
+  /** Labels for a "by" aggregation clause. */
+  by?: string[];
+  /** Labels for a "without" aggregation clause. */
+  without?: string[];
+  /** Whether the grouping clause appears before or after the argument list. */
+  groupingPosition?: 'before' | 'after';
+}
+
+/**
+ * Creates a PromQL function call or aggregation.
+ *
+ * ```ts
+ * pqlFunc("rate", pqlSel("metric", "5m"))
+ * // rate(metric[5m])
+ *
+ * pqlFunc("sum", expr, { by: ["job"] })
+ * // sum(expr) by (job)
+ *
+ * pqlFunc("sum", expr, { by: ["job"], groupingPosition: "before" })
+ * // sum by (job) (expr)
+ *
+ * pqlFunc("histogram_quantile", [pqlNum(0.95), pqlSel("le_bucket", "5m")])
+ * // histogram_quantile(0.95, le_bucket[5m])
+ * ```
+ */
+export const pqlFunc = (
+  name: string,
+  args: PromQLAstExpression | PromQLAstExpression[],
+  opts?: PqlFuncOpts
+): PromQLFunction => {
+  const argsArray = Array.isArray(args) ? args : [args];
+
+  let grouping;
+  if (opts?.by) {
+    grouping = PromQLBuilder.grouping(
+      'by',
+      opts.by.map((l) => PromQLBuilder.identifier(l))
+    );
+  } else if (opts?.without) {
+    grouping = PromQLBuilder.grouping(
+      'without',
+      opts.without.map((l) => PromQLBuilder.identifier(l))
+    );
+  }
+
+  return SynthNode.from(
+    PromQLBuilder.expression.func.call(name, argsArray, grouping, opts?.groupingPosition)
+  );
+};
+
+/**
+ * Options for `pqlBinary`.
+ */
+export interface PqlBinaryOpts {
+  /** Turns a comparison into a scalar. */
+  bool?: boolean;
+  /** Vector matching "on". */
+  on?: string[];
+  /** Vector matching "ignoring". */
+  ignoring?: string[];
+  groupLeft?: string[];
+  groupRight?: string[];
+}
+
+/**
+ * Creates a PromQL binary expression.
+ *
+ * ```ts
+ * pqlBinary("+", a, b)
+ * // a + b
+ *
+ * pqlBinary("==", a, b, { bool: true })
+ * // a == bool b
+ *
+ * pqlBinary("/", a, b, { on: ["job"], groupLeft: [] })
+ * // a / on(job) group_left() b
+ * ```
+ */
+export const pqlBinary = <Name extends PromQLBinaryOperator>(
+  op: Name,
+  left: PromQLAstExpression,
+  right: PromQLAstExpression,
+  opts?: PqlBinaryOpts
+): PromQLBinaryExpression<Name> => {
+  let modifier;
+  if (opts?.on !== undefined || opts?.ignoring !== undefined) {
+    const kind = opts.on !== undefined ? ('on' as const) : ('ignoring' as const);
+    const labelIds = (opts.on ?? opts.ignoring ?? []).map((l) => PromQLBuilder.identifier(l));
+
+    let groupMod;
+    if (opts.groupLeft !== undefined) {
+      groupMod = PromQLBuilder.groupModifier(
+        'group_left',
+        opts.groupLeft.map((l) => PromQLBuilder.identifier(l))
+      );
+    } else if (opts.groupRight !== undefined) {
+      groupMod = PromQLBuilder.groupModifier(
+        'group_right',
+        opts.groupRight.map((l) => PromQLBuilder.identifier(l))
+      );
+    }
+
+    modifier = PromQLBuilder.modifier(kind, labelIds, groupMod);
+  }
+
+  return SynthNode.from(
+    PromQLBuilder.expression.binary(op, left, right, { bool: opts?.bool, modifier })
+  );
+};
+
+/**
+ * Creates a PromQL unary expression.
+ */
+export const pqlUnary = (op: '+' | '-', arg: PromQLAstExpression): PromQLUnaryExpression =>
+  SynthNode.from(PromQLBuilder.expression.unary(op, arg));
+
+/**
+ * Wraps a PromQL expression in parentheses.
+ */
+export const pqlParens = (child: PromQLAstExpression): PromQLParens =>
+  SynthNode.from(PromQLBuilder.expression.parens(child));
+
+/**
+ * Creates a PromQL subquery expression.
+ *
+ * ```ts
+ * pqlSubquery(expr, "30m")       // expr[30m:]
+ * pqlSubquery(expr, "30m", "5m") // expr[30m:5m]
+ * ```
+ */
+export const pqlSubquery = (
+  expr: PromQLAstExpression,
+  range: string,
+  resolution?: string
+): PromQLSubquery =>
+  SynthNode.from(
+    PromQLBuilder.expression.subquery(
+      expr,
+      PromQLBuilder.expression.literal.time(range),
+      resolution !== undefined ? PromQLBuilder.expression.literal.time(resolution) : undefined
+    )
+  );
+
+/**
+ * Creates a PromQL `offset` modifier for use in selectors or subqueries.
+ *
+ * ```ts
+ * pqlOffset("5m")        // offset 5m
+ * pqlOffset("5m", true)  // offset - 5m
+ * ```
+ */
+export const pqlOffset = (duration: string, negative = false): PromQLOffset =>
+  SynthNode.from(PromQLBuilder.offset(PromQLBuilder.expression.literal.time(duration), negative));
+
+/**
+ * Creates a PromQL `@` modifier for use in selectors or subqueries.
+ *
+ * ```ts
+ * pqlAt("start()")    // @ start()
+ * pqlAt("end()")      // @ end()
+ * pqlAt("1609459200") // @ 1609459200
+ * ```
+ */
+export const pqlAt = (value: string, negative = false): PromQLAt => {
+  const atValue =
+    value === 'start()' || value === 'end()'
+      ? (value as 'start()' | 'end()')
+      : PromQLBuilder.expression.literal.time(value);
+
+  return SynthNode.from(PromQLBuilder.at(atValue, negative));
+};

--- a/src/composer/synth/synth_node.ts
+++ b/src/composer/synth/synth_node.ts
@@ -9,6 +9,9 @@ import { Walker } from '../../ast/walker';
 import { Builder } from '../../ast/builder';
 import { BasicPrettyPrinter } from '../../pretty_print';
 import { printAst, type PrintAstOptions } from '../../debug';
+import { PromQLBasicPrettyPrinter } from '../../embedded_languages/promql/pretty_print/basic_pretty_printer';
+import { isPromqlNode } from '../../ast/walker/helpers';
+import { PromQLAstNode } from '../../embedded_languages';
 import type { ESQLProperNode } from '../../types';
 
 /**
@@ -23,13 +26,15 @@ import type { ESQLProperNode } from '../../types';
  * ```
  */
 export class SynthNode {
-  public static from<N extends ESQLProperNode>(node: N): N & SynthNode {
+  public static from<N extends ESQLProperNode | PromQLAstNode>(node: N): N & SynthNode {
     // Remove parser generated fields.
-    Walker.walk(node, {
-      visitAny: (n) => {
-        Object.assign(n, Builder.parserFields({}));
-      },
-    });
+    if (!isPromqlNode(node)) {
+      Walker.walk(node, {
+        visitAny: (n) => {
+          Object.assign(n, Builder.parserFields({}));
+        },
+      });
+    }
 
     node = Object.assign(new SynthNode(), node);
 
@@ -37,6 +42,10 @@ export class SynthNode {
   }
 
   toString(this: ESQLProperNode) {
+    if (isPromqlNode(this)) {
+      return PromQLBasicPrettyPrinter.print(this);
+    }
+
     return BasicPrettyPrinter.print(this);
   }
 

--- a/src/composer/synth/types.ts
+++ b/src/composer/synth/types.ts
@@ -7,6 +7,7 @@
 
 import type { ParseOptions } from '../../parser';
 import type { ESQLAstExpression, ESQLProperNode } from '../../types';
+import type { PromQLAstExpression } from '../../embedded_languages/promql/types';
 import type { SynthLiteralFragment } from './synth_literal_fragment';
 import type { SynthNode } from './synth_node';
 
@@ -14,9 +15,15 @@ export type SynthGenerator<N extends ESQLProperNode> = (src: string, opts?: Pars
 
 export type SynthTemplateHole =
   /**
-   * A hole is normally an AST node.
+   * A hole is normally an ES|QL AST node.
    */
   | ESQLAstExpression
+
+  /**
+   * PromQL AST expression nodes can be interpolated directly into templates
+   * containing a PROMQL command.
+   */
+  | PromQLAstExpression
 
   /**
    * If a list of AST nodes is provided, it will be joined with a comma.

--- a/src/composer/types.ts
+++ b/src/composer/types.ts
@@ -7,6 +7,10 @@
 
 import type * as synth from './synth';
 import type { ESQLAstCommand, ESQLCommand, ESQLOrderExpression, ESQLSource } from '../types';
+import type {
+  PromQLAstExpression,
+  PromQLAstQueryExpression,
+} from '../embedded_languages/promql/types';
 import type { ComposerQuery } from './composer_query';
 import type { ParameterHole, DoubleParameterHole } from './parameter_hole';
 
@@ -151,6 +155,42 @@ export interface ComposerQueryTagMethods extends Omit<SynthMethods, 'par' | 'dpa
   ts: FromSourcesQueryStarter & FromSourcesAndMetadataQueryStarter;
 
   /**
+   * Creates a new {@linkcode ComposerQuery} starting with a `PROMQL` source
+   * command. The expression can be any PromQL AST node (from node builders or
+   * the `pql` tag) or a raw PromQL string.
+   *
+   * Basic example:
+   *
+   * ```typescript
+   * const query = esql.promql(pqlFunc('rate', pqlSel('http_requests_total', '5m')));
+   * // PROMQL (rate(http_requests_total[5m]))
+   * ```
+   *
+   * With command-level params:
+   *
+   * ```typescript
+   * const query = esql.promql(pqlSel('up'), { params: { index: 'k8s' } });
+   * // PROMQL index=k8s (up)
+   * ```
+   *
+   * With a named output column:
+   *
+   * ```typescript
+   * const query = esql.promql(pqlFunc('sum', pqlSel('m', '5m')), { outputName: 'result' });
+   * // PROMQL result = (sum(m[5m]))
+   * ```
+   *
+   * Pipe additional processing commands as usual:
+   *
+   * ```typescript
+   * esql.promql(pqlFunc('rate', pqlSel('m', '5m')))
+   *   .limit(100)
+   *   .sort(['@timestamp', 'DESC']);
+   * ```
+   */
+  promql: PromqlQueryStarter;
+
+  /**
    * An AST no-op command that can be used in the query, for example in
    * conditional expressions.
    *
@@ -178,6 +218,44 @@ export type FromSourcesQueryStarter = (
 export type FromSourcesAndMetadataQueryStarter = (
   sources: ComposerSourceShorthand[],
   metadataFields?: ComposerColumnShorthand[]
+) => ComposerQuery;
+
+/**
+ * A PromQL expression that can be passed to {@link PromqlQueryStarter}.
+ */
+export type PromqlExpressionInput = PromQLAstExpression | PromQLAstQueryExpression | string;
+
+/**
+ * Options for {@link PromqlQueryStarter}.
+ */
+export interface PromqlStarterOpts {
+  /**
+   * Static key-value metadata parameters placed before the expression.
+   *
+   * ```typescript
+   * { params: { index: 'k8s', timeout: '10s' } }
+   * // PROMQL index=k8s timeout=10s (expr)
+   * ```
+   */
+  params?: Record<string, string>;
+
+  /**
+   * Names the query output column using assignment syntax.
+   *
+   * ```typescript
+   * { outputName: 'result' }
+   * // PROMQL result = (expr)
+   * ```
+   */
+  outputName?: string;
+}
+
+/**
+ * The signature of {@link ComposerQueryTagMethods.promql}.
+ */
+export type PromqlQueryStarter = (
+  expression: PromqlExpressionInput,
+  opts?: PromqlStarterOpts
 ) => ComposerQuery;
 
 /**

--- a/src/embedded_languages/promql/pretty_print/basic_pretty_printer.ts
+++ b/src/embedded_languages/promql/pretty_print/basic_pretty_printer.ts
@@ -118,12 +118,22 @@ export class PromQLBasicPrettyPrinter {
     return this.printExpression(query.expression);
   }
 
-  public printExpression(expr: PromQLAstExpression | undefined): string {
+  public printExpression(
+    expr: PromQLAstExpression | PromQLLabel | PromQLLabelMap | PromQLOffset | PromQLAt | undefined
+  ): string {
     if (!expr) {
       return '';
     }
 
     switch (expr.type) {
+      case 'label':
+        return this.printLabel(expr);
+      case 'label-map':
+        return this.printLabelMap(expr);
+      case 'offset':
+        return this.printOffset(expr);
+      case 'at':
+        return this.printAt(expr);
       case 'function':
         return this.printFunction(expr);
       case 'selector':


### PR DESCRIPTION
## Summary

Adds PromQL support to Synt and Composer APIs for programmatic query construction - now with PromQL expressions.

### Checklist

- [x] Unit tests have been added or updated.
- [ ] The proper documentation has been added or updated.
- [x] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax.
- [x] The PR title has the correct [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) label in the title, this is crucial for the correct versioning of this package. Check the following cheat shit.
