### PR TITLE
docs: Add some skills for the agents

### DIFF
--- a/.agents/skills/grammar-sync-update/SKILL.md
+++ b/.agents/skills/grammar-sync-update/SKILL.md
@@ -2,36 +2,52 @@
 name: grammar-sync-update
 description: >
   Use this skill when a grammar sync PR has landed (updating src/parser/antlr/) and a follow-up PR
-  is needed to wire a new ES|QL command into the AST layer. Covers all 7 files that need changes
-  and the exact patterns to follow.
+  is needed to wire a new ES|QL command or update an existing one in the AST layer. Covers all files
+  that need changes and the exact patterns to follow for both new and existing commands.
 ---
 
 # Grammar Sync Update
 
 ## When to use
 
-After the automated grammar sync bot merges a PR that adds a **new command**, run this skill to produce the follow-up wiring PR.
+After the automated grammar sync bot merges a PR, this skill covers two scenarios:
+
+**Scenario A — New command** (7 files to change): A brand-new `xxxCommand` rule appeared in the grammar with no handler anywhere in the TypeScript layer.
+
+**Scenario B — Existing command update** (1–3 files to change): An existing command's grammar rule gained a new option, new labeled field, or new sub-rule (e.g. `CHANGE_POINT` gained `BY`, `WHERE IN` gained subquery support).
 
 **You do NOT need this skill when:**
 - The grammar sync PR only updated ANTLR-generated files with no new grammar rules (`.ts`, `.interp`, `.tokens` only) — those are handled automatically.
 
 **You DO need this skill when:**
-- A new `xxxCommand` rule appears in `src/parser/antlr/esql_parser.g4` with no corresponding `fromXxxCommand()` in `cst_to_ast_converter.ts`.
-- The `esql_parser_listener.ts` has new `enterXxxCommand` / `exitXxxCommand` entries with no converter handler.
+- A new `xxxCommand` rule appears in `src/parser/antlr/esql_parser.g4` with no corresponding `fromXxxCommand()` in `cst_to_ast_converter.ts`. → **Use Scenario A below.**
+- The `esql_parser_listener.ts` has new `enterXxxCommand` / `exitXxxCommand` entries with no converter handler. → **Use Scenario A below.**
+- An existing command's grammar rule changed (new context method, new labeled alternative, new keyword option) and the converter no longer covers it. → **Use Scenario B below.**
 
 ## How to detect what changed
 
 ```bash
-# Find new command rules added in the grammar sync commit
+# 1. See the full grammar diff
+git diff HEAD~1 -- src/parser/antlr/esql_parser.g4
+
+# 2. Identify new command rules (Scenario A)
 git diff HEAD~1 -- src/parser/antlr/esql_parser.g4 | grep "^+.*[Cc]ommand\b"
 
-# Cross-check: listener entries without a converter method
+# 3. Cross-check: listener entries without a converter handler (Scenario A)
 grep "enter.*Command" src/parser/antlr/esql_parser_listener.ts | \
   sed 's/.*enter\([A-Za-z]*\)Command.*/\1/' | \
   while read cmd; do
     grep -q "from${cmd}Command" src/parser/core/cst_to_ast_converter.ts || echo "MISSING: $cmd"
   done
+
+# 4. Identify changed rules for existing commands (Scenario B)
+# Look for new labeled alternatives (_newField), new keyword tokens (BY, WITH, AS),
+# or new sub-rule methods (ctx.newSubRule()) added to an existing command rule.
+git diff HEAD~1 -- src/parser/antlr/esql_parser.g4 | grep "^[+-]" | grep -v "^---\|^+++"
 ```
+
+If step 2/3 shows an entirely new command → **Scenario A**.
+If step 4 shows additions inside an existing command rule → **Scenario B**.
 
 ---
 
@@ -245,7 +261,7 @@ Reference test files: `src/parser/__tests__/user_agent.test.ts`, `src/parser/__t
 
 ---
 
-## Checklist
+## Checklist — Scenario A (new command)
 
 - [ ] `src/types.ts` — new interface + union updated
 - [ ] `src/ast/visitor/contexts.ts` — `XxxCommandVisitorContext` added
@@ -257,6 +273,105 @@ Reference test files: `src/parser/__tests__/user_agent.test.ts`, `src/parser/__t
 - [ ] `yarn test` passes
 - [ ] `yarn build` passes (no TypeScript errors)
 - [ ] `yarn lint` passes
+
+---
+
+## Scenario B — Existing command update
+
+The grammar changed an **existing** command's rule: it gained a new option keyword (`BY`, `WITH`, `AS`), a new labeled alternative (`_newField`), or a new sub-rule. The converter method already exists — you only need to extend it.
+
+### Files to change
+
+#### `src/parser/core/cst_to_ast_converter.ts`
+
+Find the existing `fromXxxCommand()` method and add handling for what's new.
+
+**New keyword option** (e.g. `CHANGE_POINT … BY field1, field2`):
+```ts
+if (ctx.BY()) {
+  const args = (ctx._groupings ?? [])
+    .filter((e) => !e.exception)
+    .map((e) => this.fromBooleanExpressionToExpressionOrUnknown(e));
+
+  const byOption = this.toByOption(ctx, args);
+  if (byOption) {
+    command.args.push(byOption);
+    command.incomplete ||= byOption.incomplete;
+  }
+}
+```
+
+**New labeled field** (e.g. `_targetField` added to an existing rule):
+```ts
+if (ctx._targetField) {
+  const col = this.toColumn(ctx._targetField);
+  command.targetField = col;   // only if types.ts interface has this field
+  command.args.push(col);
+}
+```
+
+**New sub-rule variant** (e.g. `WHERE IN` gained a `LogicalInSubquery` alternative):
+```ts
+// In the existing expression handler, add a branch before the current logic:
+if (ctx instanceof cst.LogicalInSubqueryContext) {
+  return this.fromLogicalInSubquery(ctx);
+}
+// then add the new private method:
+private fromLogicalInSubquery(ctx: cst.LogicalInSubqueryContext): ast.ESQLAstExpression {
+  const left = this.fromLogicalInLeft(ctx.valueExpression());
+  const right = this.fromSubquery(ctx.subquery());
+  return this.toLogicalInFunction(ctx, left, right, ctx.stop?.stop ?? right.location.max);
+}
+```
+
+#### `src/types.ts` — only if the command gains new named fields
+
+If the existing interface (e.g. `ESQLAstChangePointCommand`) needs to expose the new option as a typed field, add it:
+```ts
+export interface ESQLAstChangePointCommand extends ESQLCommand<'change_point'> {
+  value: ESQLColumn;
+  key?: ESQLColumn;
+  target?: { type: ESQLColumn; pvalue: ESQLColumn };
+  // ← add new field only if consumers need typed access
+}
+```
+
+Skip this if the new option is only accessible via generic `args` — that's fine for options that don't need first-class API access.
+
+#### Tests
+
+Always update or add tests. For an existing command update, add to the existing test file (`src/parser/__tests__/xxx.test.ts`) rather than creating a new one.
+
+Cover:
+1. The new option/field parses correctly
+2. The AST shape is correct (`toMatchObject`)
+3. The pretty-printer round-trips the new syntax
+4. Walker traversal visits any new nodes (if the new option introduces new AST nodes)
+
+**Real example — `CHANGE_POINT BY`** (PR #104):
+- Added 21 lines to `change_point.test.ts`
+- Added 14 lines to `fromChangePointCommand()` in `cst_to_ast_converter.ts`
+- No `types.ts` change (BY option fits in generic `args`)
+- No visitor changes
+
+**Real example — `WHERE IN` subquery** (PR #107):
+- Refactored `fromLogicalIn()` in `cst_to_ast_converter.ts` into smaller methods + added subquery branch
+- Added tests to `src/parser/__tests__/function.test.ts` and `src/ast/walker/__tests__/walker.test.ts`
+- Added pretty-printer tests to 4 existing test files
+- No `types.ts` or visitor changes (subquery uses existing `ESQLParens` type)
+
+### Checklist — Scenario B (existing command update)
+
+- [ ] `src/parser/core/cst_to_ast_converter.ts` — existing handler extended
+- [ ] `src/types.ts` — interface updated only if new named fields are needed
+- [ ] Tests added/extended in existing test file
+- [ ] Pretty-printer tests added if new syntax affects printing
+- [ ] Walker tests added if new syntax introduces new traversable nodes
+- [ ] `yarn test` passes
+- [ ] `yarn build` passes
+- [ ] `yarn lint` passes
+
+---
 
 ## Reference: simple vs complex existing commands
 

--- a/.agents/skills/grammar-sync-update/SKILL.md
+++ b/.agents/skills/grammar-sync-update/SKILL.md
@@ -65,7 +65,7 @@ export interface ESQLAstXxxCommand extends ESQLCommand<'xxx'> {
 }
 ```
 
-Add it to the `ESQLAstCommand` union (around line 15):
+Add it to the `ESQLAstCommand` union (search for `ESQLAstCommand` type definition):
 
 ```ts
 export type ESQLAstCommand =
@@ -80,7 +80,7 @@ If the command is trivial (only generic `args`, no named fields), use `ESQLComma
 
 ### 2. `src/ast/visitor/contexts.ts`
 
-Add a visitor context class near the end of the command context section (before the `// Expressions` comment, around line 613):
+Add a visitor context class before the `// Expressions` comment (search for that comment to find the spot):
 
 ```ts
 // XXX <qualifiedName> = <primaryExpression> [WITH <map>]
@@ -96,19 +96,19 @@ Also add the import for `ESQLAstXxxCommand` at the top of the file.
 
 ### 3. `src/ast/visitor/types.ts`
 
-Three additions (search for `visitUserAgentCommand` to find the right spots):
+Three additions. Search for `agent-marker` comments to find the exact insertion points:
 
-**A — `CommandVisitorInput` union** (all command inputs are ANDed together, ~line 116):
+**A — `CommandVisitorInput` union** (search for `agent-marker: append new VisitorInput entries here`):
 ```ts
 VisitorInput<Methods, 'visitXxxCommand'> &
 ```
 
-**B — `CommandVisitorOutput` union** (all command outputs are ORed together, ~line 152):
+**B — `CommandVisitorOutput` union** (search for `agent-marker: append new VisitorOutput entries here`):
 ```ts
 | VisitorOutput<Methods, 'visitXxxCommand'>
 ```
 
-**C — `VisitorMethods` interface** (~line 216):
+**C — `VisitorMethods` interface** (search for `visitUserAgentCommand?` — the last method — and append after it):
 ```ts
 visitXxxCommand?: Visitor<contexts.XxxCommandVisitorContext<Visitors, Data>, any, any>;
 ```
@@ -119,7 +119,7 @@ visitXxxCommand?: Visitor<contexts.XxxCommandVisitorContext<Visitors, Data>, any
 
 Two additions:
 
-**A — dispatcher `switch` case** (inside `visitCommandSpecific`, around line 258):
+**A — dispatcher `switch` case** (search for `visitCommandSpecific` — add a new `case` inside the `switch`):
 ```ts
 case 'xxx': {
   if (!this.methods.visitXxxCommand) break;
@@ -131,7 +131,7 @@ case 'xxx': {
 }
 ```
 
-**B — public visitor method** (after the last `visitXxxCommand` method, around line 572):
+**B — public visitor method** (search for `visitUserAgentCommand` — the last public visitor method — and append after it):
 ```ts
 public visitXxxCommand(
   parent: contexts.VisitorContext | null,
@@ -151,7 +151,7 @@ Add the import for `ESQLAstXxxCommand` at the top of the file.
 
 Two additions:
 
-**A — dispatcher** (inside the `if/else if` chain around line 440, after existing commands):
+**A — dispatcher** (search for `agent-marker: append new command dispatcher branches here` and add before it):
 ```ts
 const xxxCommandCtx = ctx.xxxCommand();
 

--- a/.agents/skills/grammar-sync-update/SKILL.md
+++ b/.agents/skills/grammar-sync-update/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: grammar-sync-update
+description: >
+  Use this skill when a grammar sync PR has landed (updating src/parser/antlr/) and a follow-up PR
+  is needed to wire a new ES|QL command into the AST layer. Covers all 7 files that need changes
+  and the exact patterns to follow.
+---
+
+# Grammar Sync Update
+
+## When to use
+
+After the automated grammar sync bot merges a PR that adds a **new command**, run this skill to produce the follow-up wiring PR.
+
+**You do NOT need this skill when:**
+- The grammar sync PR only updated ANTLR-generated files with no new grammar rules (`.ts`, `.interp`, `.tokens` only) — those are handled automatically.
+
+**You DO need this skill when:**
+- A new `xxxCommand` rule appears in `src/parser/antlr/esql_parser.g4` with no corresponding `fromXxxCommand()` in `cst_to_ast_converter.ts`.
+- The `esql_parser_listener.ts` has new `enterXxxCommand` / `exitXxxCommand` entries with no converter handler.
+
+## How to detect what changed
+
+```bash
+# Find new command rules added in the grammar sync commit
+git diff HEAD~1 -- src/parser/antlr/esql_parser.g4 | grep "^+.*[Cc]ommand\b"
+
+# Cross-check: listener entries without a converter method
+grep "enter.*Command" src/parser/antlr/esql_parser_listener.ts | \
+  sed 's/.*enter\([A-Za-z]*\)Command.*/\1/' | \
+  while read cmd; do
+    grep -q "from${cmd}Command" src/parser/core/cst_to_ast_converter.ts || echo "MISSING: $cmd"
+  done
+```
+
+---
+
+## Files to change (all 7, in order)
+
+### 1. `src/types.ts`
+
+**Add a typed interface** if the command has named fields (target field, inference ID, optional config, etc.):
+
+```ts
+export interface ESQLAstXxxCommand extends ESQLCommand<'xxx'> {
+  targetField: ESQLColumn;          // if there's a <qualifiedName> = <expr> pattern
+  expression?: ESQLAstExpression;   // the RHS
+  namedParameters?: ESQLMap;        // if there's a WITH { map } clause
+}
+```
+
+Add it to the `ESQLAstCommand` union (around line 15):
+
+```ts
+export type ESQLAstCommand =
+  | ESQLCommand
+  | ...
+  | ESQLAstXxxCommand;   // ← add here
+```
+
+If the command is trivial (only generic `args`, no named fields), use `ESQLCommand<'xxx'>` directly and skip the interface.
+
+---
+
+### 2. `src/ast/visitor/contexts.ts`
+
+Add a visitor context class near the end of the command context section (before the `// Expressions` comment, around line 613):
+
+```ts
+// XXX <qualifiedName> = <primaryExpression> [WITH <map>]
+export class XxxCommandVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData,
+> extends CommandVisitorContext<Methods, Data, ESQLAstXxxCommand> {}
+```
+
+Also add the import for `ESQLAstXxxCommand` at the top of the file.
+
+---
+
+### 3. `src/ast/visitor/types.ts`
+
+Three additions (search for `visitUserAgentCommand` to find the right spots):
+
+**A — `CommandVisitorInput` union** (all command inputs are ANDed together, ~line 116):
+```ts
+VisitorInput<Methods, 'visitXxxCommand'> &
+```
+
+**B — `CommandVisitorOutput` union** (all command outputs are ORed together, ~line 152):
+```ts
+| VisitorOutput<Methods, 'visitXxxCommand'>
+```
+
+**C — `VisitorMethods` interface** (~line 216):
+```ts
+visitXxxCommand?: Visitor<contexts.XxxCommandVisitorContext<Visitors, Data>, any, any>;
+```
+
+---
+
+### 4. `src/ast/visitor/global_visitor_context.ts`
+
+Two additions:
+
+**A — dispatcher `switch` case** (inside `visitCommandSpecific`, around line 258):
+```ts
+case 'xxx': {
+  if (!this.methods.visitXxxCommand) break;
+  return this.visitXxxCommand(
+    parent,
+    commandNode as ESQLAstXxxCommand,
+    input as any
+  );
+}
+```
+
+**B — public visitor method** (after the last `visitXxxCommand` method, around line 572):
+```ts
+public visitXxxCommand(
+  parent: contexts.VisitorContext | null,
+  node: ESQLAstXxxCommand,
+  input: types.VisitorInput<Methods, 'visitXxxCommand'>
+): types.VisitorOutput<Methods, 'visitXxxCommand'> {
+  const context = new contexts.XxxCommandVisitorContext(this, node, parent);
+  return this.visitWithSpecificContext('visitXxxCommand', context, input);
+}
+```
+
+Add the import for `ESQLAstXxxCommand` at the top of the file.
+
+---
+
+### 5. `src/parser/core/cst_to_ast_converter.ts`
+
+Two additions:
+
+**A — dispatcher** (inside the `if/else if` chain around line 440, after existing commands):
+```ts
+const xxxCommandCtx = ctx.xxxCommand();
+
+if (xxxCommandCtx) {
+  return this.fromXxxCommand(xxxCommandCtx);
+}
+```
+
+**B — converter method**:
+
+```ts
+private fromXxxCommand(ctx: cst.XxxCommandContext): ast.ESQLAstXxxCommand {
+  const command = this.createCommand<'xxx', ast.ESQLAstXxxCommand>('xxx', ctx);
+
+  // Assignment pattern: targetField = expression
+  if (ctx._targetField && ctx.ASSIGN()) {
+    const targetField = this.toColumn(ctx._targetField);
+    const expression = this.fromPrimaryExpression(ctx.primaryExpression());
+    const assignment = this.toFunction('=', ctx, undefined, 'binary-expression') as ast.ESQLBinaryExpression;
+    assignment.args.push(targetField, expression);
+    assignment.location = this.extendLocationToArgs(assignment);
+    command.targetField = targetField;
+    command.expression = expression;
+    command.args.push(assignment);
+  }
+
+  // Optional WITH { map } clause
+  const withOption = this.fromOptionalNamedParametersWithOption(ctx.namedParametersWithOption());
+  if (withOption) {
+    command.namedParameters = withOption.args[0] as ast.ESQLMap;
+    command.args.push(withOption);
+  }
+
+  if (ctx.exception) {
+    command.incomplete = true;
+  }
+
+  return command;
+}
+```
+
+**Patterns by grammar shape** — pick the one that matches:
+
+| Grammar shape | Converter call |
+|---|---|
+| Single column / qualified name | `this.toColumn(ctx._field)` |
+| Primary expression | `this.fromPrimaryExpression(ctx.primaryExpression())` |
+| Constant literal | `this.fromConstantToArray(ctx.constant())` |
+| String token | `this.fromStringToken(ctx.STRING().symbol)` |
+| Repeated sub-rule list | `ctx.xxxConfiguration_list()` loop |
+| Boolean expression | `this.fromBooleanExpression(ctx.booleanExpression())` |
+| Named option (`KEYWORD field`) | `Builder.option({ name: 'keyword', args: [...] }, { location })` |
+| Assignment `target = expr` | `this.toFunction('=', ctx, undefined, 'binary-expression')` |
+| WITH `{ map }` | `this.fromOptionalNamedParametersWithOption(ctx.namedParametersWithOption())` |
+
+---
+
+### 6. `src/pretty_print/constants.ts`
+
+The pretty printer is visitor-based and **requires no changes** for most new commands.
+
+Only update when:
+- Command args have **no commas** between them → add to `commandsWithNoCommaArgSeparator`
+- A command option uses `=` instead of a space before its value → add to `commandOptionsWithEqualsSeparator`
+
+```ts
+export const commandsWithNoCommaArgSeparator = new Set([
+  'dissect', 'sample', 'fork', 'promql',
+  'xxx', // ← add only if needed
+]);
+```
+
+---
+
+### 7. `src/parser/__tests__/xxx.test.ts` (new file)
+
+Minimum coverage:
+1. Parses basic syntax without errors
+2. AST shape matches expected structure (`toMatchObject`)
+3. Verifies `incomplete` flag for partial input
+4. Round-trips through the pretty-printer
+
+```ts
+import { parse } from '..';
+import { BasicPrettyPrinter } from '../../pretty_print';
+
+describe('XXX command', () => {
+  it('parses basic syntax', () => {
+    const { ast, errors } = parse('FROM a | XXX target = field');
+    expect(errors).toHaveLength(0);
+    expect(ast[1]).toMatchObject({
+      type: 'command',
+      name: 'xxx',
+      targetField: { type: 'column', name: 'target' },
+    });
+  });
+
+  it('round-trips through the printer', () => {
+    const src = 'FROM a | XXX target = field';
+    const { ast } = parse(src);
+    expect(BasicPrettyPrinter.query(ast)).toBe(src.toUpperCase());
+  });
+});
+```
+
+Reference test files: `src/parser/__tests__/user_agent.test.ts`, `src/parser/__tests__/change_point.test.ts`
+
+---
+
+## Checklist
+
+- [ ] `src/types.ts` — new interface + union updated
+- [ ] `src/ast/visitor/contexts.ts` — `XxxCommandVisitorContext` added
+- [ ] `src/ast/visitor/types.ts` — input union, output union, `VisitorMethods` updated
+- [ ] `src/ast/visitor/global_visitor_context.ts` — switch case + public method added
+- [ ] `src/parser/core/cst_to_ast_converter.ts` — dispatcher + `fromXxxCommand()` added
+- [ ] `src/pretty_print/constants.ts` — updated only if needed
+- [ ] `src/parser/__tests__/xxx.test.ts` — tests added
+- [ ] `yarn test` passes
+- [ ] `yarn build` passes (no TypeScript errors)
+- [ ] `yarn lint` passes
+
+## Reference: simple vs complex existing commands
+
+| Command | Interface | Visitor context | Test file |
+|---|---|---|---|
+| `SAMPLE` | none (generic) | none | `sample.test.ts` |
+| `URI_PARTS` | `ESQLAstUriPartsCommand` | `UriPartsCommandVisitorContext` | `uri_parts.test.ts` |
+| `USER_AGENT` | `ESQLAstUserAgentCommand` | `UserAgentCommandVisitorContext` | `user_agent.test.ts` |
+| `CHANGE_POINT` | `ESQLAstChangePointCommand` | none (no typed visitor) | `change_point.test.ts` |
+| `RERANK` | `ESQLAstRerankCommand` | `RerankCommandVisitorContext` | `rerank.test.ts` |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,5 +22,6 @@ jobs:
             refactor
             perf
             build
+            docs
             chore
             revert

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# esql-js
+
+## Setup
+- Run `yarn install` for initial setup or after switching branches.
+- Run `yarn build:antlr4` to compile ANTLR grammars after grammar files change (requires `antlr` CLI; on macOS install via `brew bundle --file=./.buildkite/scripts/antlr4_tools/brewfile`).
+
+## Overview
+This library provides an ES|QL and PromQL parser, AST builder, and pretty-printer for use in Kibana and other Elastic tooling. It is a TypeScript package compiled with `tsup` + `tsc`.
+
+### Key source areas
+| Path | Purpose |
+|------|---------|
+| `src/parser/antlr/` | Auto-generated ANTLR4 TypeScript files (lexer, parser, listener, interp). **Do not edit by hand.** |
+| `src/parser/core/cst_to_ast_converter.ts` | Converts ANTLR CST → Kibana AST. Main place to add new command support. |
+| `src/types.ts` | All public AST node types. Add new command interfaces here. |
+| `src/ast/builder/builder.ts` | Programmatic AST builder (used in tests and by consumers). |
+| `src/pretty_print/basic_pretty_printer.ts` | Visitor-based printer. Mostly generic; rarely needs changes. |
+| `src/pretty_print/constants.ts` | Sets/maps for commands with non-standard formatting rules. |
+| `src/embedded_languages/promql/` | Parallel structure for PromQL (own parser, builder, pretty-printer). |
+
+### Grammar sync pipeline
+The CI job `.buildkite/scripts/esql_grammar_sync.sh` clones `elastic/elasticsearch`, copies the ANTLR grammar files into `src/parser/antlr/`, rebuilds the TypeScript artifacts, and opens a PR automatically.
+
+That PR only touches `src/parser/antlr/`. When a grammar change adds a **new command or new grammar rule**, a follow-up PR is needed to wire the new rule into the AST layer. Use the `/grammar-sync-update` skill for this.
+
+## Testing
+```
+yarn test                    # all tests
+yarn test --testPathPattern=<file>  # single file
+yarn lint                    # ESLint
+yarn format:check            # Prettier
+yarn build                   # full build (type-check included)
+```
+
+## Code style
+- TypeScript throughout; no `any`.
+- `import type` for type-only imports.
+- `PascalCase` for classes/interfaces, `camelCase` for functions/variables.
+- No inline comments unless the WHY is non-obvious.
+- No trailing summaries in commit messages.
+
+## Contribution
+- Keep PRs focused; no unrelated refactors.
+- Never skip or comment out tests; fix the underlying code.
+- Open PRs as draft until CI is green.

--- a/src/ast/visitor/types.ts
+++ b/src/ast/visitor/types.ts
@@ -117,7 +117,7 @@ export type CommandVisitorInput<Methods extends VisitorMethods> = AnyToVoid<
     VisitorInput<Methods, 'visitTsInfoCommand'> &
     VisitorInput<Methods, 'visitMetricsInfoCommand'> &
     VisitorInput<Methods, 'visitUserAgentCommand'> &
-    VisitorInput<Methods, 'visitRegisteredDomainCommand'>
+    VisitorInput<Methods, 'visitRegisteredDomainCommand'> // agent-marker: append new VisitorInput entries here
 >;
 
 /**
@@ -153,7 +153,7 @@ export type CommandVisitorOutput<Methods extends VisitorMethods> =
   | VisitorOutput<Methods, 'visitTsInfoCommand'>
   | VisitorOutput<Methods, 'visitMetricsInfoCommand'>
   | VisitorOutput<Methods, 'visitUserAgentCommand'>
-  | VisitorOutput<Methods, 'visitRegisteredDomainCommand'>;
+  | VisitorOutput<Methods, 'visitRegisteredDomainCommand'>; // agent-marker: append new VisitorOutput entries here
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface VisitorMethods<

--- a/src/parser/core/cst_to_ast_converter.ts
+++ b/src/parser/core/cst_to_ast_converter.ts
@@ -544,6 +544,7 @@ export class CstToAstConverter {
     if (userAgentCommandCtx) {
       return this.fromUserAgentCommand(userAgentCommandCtx);
     }
+    // agent-marker: append new command dispatcher branches here
     // throw new Error(`Unknown processing command: ${this.getSrc(ctx)}`;
   }
 


### PR DESCRIPTION
## Summary

I want to make this repo more agentic. We are usually doing things that an agent can easily do. I am introducing these skills. We can iterate on them and when we feel that they are doing a good job I plan to add them on our script to run with the grammar updates. But let's use them in practice first

## Details

I am using the same patterns as kibana

### Checklist

- [x] The proper documentation has been added or updated.

