### PR TITLE
fix: correct handing of operator grouping for same precedence level operators

### DIFF
--- a/src/embedded_languages/promql/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/embedded_languages/promql/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -312,6 +312,32 @@ describe('parsed PromQL BasicPrettyPrinter', () => {
     });
   });
 
+  describe('binary operator grouping', () => {
+    test('same-group right operand: semantically needed parens preserved', () => {
+      assertReprint('a / (b * c)');
+      assertReprint('a / (b / c)');
+      assertReprint('a - (b + c)');
+      assertReprint('a - (b - c)');
+    });
+
+    test('same-group right operand: redundant parens preserved (faithful round-trip)', () => {
+      assertReprint('a * (b / c)');
+      assertReprint('a * (b * c)');
+      assertReprint('a + (b - c)');
+      assertReprint('a + (b + c)');
+    });
+
+    test('left operand parens preserved', () => {
+      assertReprint('(a / b) * c');
+      assertReprint('(a + b) - c');
+    });
+
+    test('power: right-associative same-group parens preserved', () => {
+      assertReprint('a ^ (b ^ c)');
+      assertReprint('(a ^ b) ^ c');
+    });
+  });
+
   describe('function calls', () => {
     describe('basic functions', () => {
       test('no argument function', () => {

--- a/src/embedded_languages/promql/pretty_print/__tests__/wrapping_pretty_printer.test.ts
+++ b/src/embedded_languages/promql/pretty_print/__tests__/wrapping_pretty_printer.test.ts
@@ -247,6 +247,33 @@ describe('PromQL WrappingPrettyPrinter', () => {
     });
   });
 
+  describe('binary operator grouping', () => {
+    test('same-group right operand: semantically needed parens preserved', () => {
+      assertPrint('a / (b * c)');
+      assertPrint('a / (b / c)');
+      assertPrint('a - (b + c)');
+      assertPrint('a - (b - c)');
+    });
+
+    test('same-group right operand: redundant parens preserved', () => {
+      assertPrint('a * (b / c)');
+      assertPrint('a * (b * c)');
+      assertPrint('a + (b - c)');
+      assertPrint('a + (b + c)');
+    });
+
+    test('parens preserved when outer expression wraps', () => {
+      assertNarrowPrint('long_left_metric / (b * c)', 'long_left_metric\n  / (b * c)', 20);
+      assertNarrowPrint('long_left_metric - (b + c)', 'long_left_metric\n  - (b + c)', 20);
+      assertNarrowPrint('long_left_metric * (b / c)', 'long_left_metric\n  * (b / c)', 20);
+    });
+
+    test('power: right-associative same-group parens preserved', () => {
+      assertPrint('a ^ (b ^ c)');
+      assertPrint('(a ^ b) ^ c');
+    });
+  });
+
   describe('subqueries', () => {
     test('simple subquery', () => {
       assertPrint('rate(http_requests_total[5m])[30m:1m]');

--- a/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -719,6 +719,37 @@ describe('single line query', () => {
             expect(text).toBe('FROM index | EVAL a = b / (c * 10)');
           });
 
+          test('division: same-group right operand always needs brackets', () => {
+            assertReprint('FROM a | WHERE b / (c * 10)');
+            assertReprint('FROM a | WHERE b / (c / 10)');
+            assertReprint('FROM a | WHERE b / (c % 10)');
+          });
+
+          test('division: left operand brackets at same group are redundant', () => {
+            assertReprint('FROM a | WHERE (b / c) * 10', 'FROM a | WHERE b / c * 10');
+            assertReprint('FROM a | WHERE (b * c) / 10', 'FROM a | WHERE b * c / 10');
+          });
+
+          test('subtraction: same-group right operand always needs brackets', () => {
+            assertReprint('FROM a | WHERE a - (b + c)');
+            assertReprint('FROM a | WHERE a - (b - c)');
+          });
+
+          test('addition: same-group right operand brackets are redundant', () => {
+            assertReprint('FROM a | WHERE a + (b + c)', 'FROM a | WHERE a + b + c');
+            assertReprint('FROM a | WHERE a + (b - c)', 'FROM a | WHERE a + b - c');
+          });
+
+          test('multiplication: same-group right operand brackets are redundant', () => {
+            assertReprint('FROM a | WHERE a * (b * c)', 'FROM a | WHERE a * b * c');
+            assertReprint('FROM a | WHERE a * (b / c)', 'FROM a | WHERE a * b / c');
+          });
+
+          test('modulo: same-group right operand always needs brackets', () => {
+            assertReprint('FROM a | WHERE a % (b * c)');
+            assertReprint('FROM a | WHERE a % (b / c)');
+          });
+
           test('inserts brackets where necessary due precedence', () => {
             const { text } = reprint('FROM a | WHERE (1 + 2) * 3');
 

--- a/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -713,6 +713,12 @@ describe('single line query', () => {
         });
 
         describe('grouping', () => {
+          test('brackets preserved in division numerator', () => {
+            const { text } = reprint('FROM index | EVAL a = b / (c * 10)');
+
+            expect(text).toBe('FROM index | EVAL a = b / (c * 10)');
+          });
+
           test('inserts brackets where necessary due precedence', () => {
             const { text } = reprint('FROM a | WHERE (1 + 2) * 3');
 

--- a/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
+++ b/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
@@ -1451,6 +1451,23 @@ FROM a
 });
 
 describe('unary operator precedence and grouping', () => {
+  test('brackets preserved in division numerator', () => {
+    const { text } = reprint(
+      'FROM index | EVAL aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb / (ccccccccccccccccccccccccccccccccccccccccccccc * 100000000000)'
+    );
+
+    expect(text).toBe(
+      'FROM index\n' +
+        '  | EVAL\n' +
+        '      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =\n' +
+        '        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb /\n' +
+        '          (ccccccccccccccccccccccccccccccccccccccccccccc *\n' +
+        '          100000000000)'
+    );
+  });
+});
+
+describe('unary operator precedence and grouping', () => {
   test('NOT should not parenthesize literals', () => {
     assertReprint('ROW NOT a');
     assertReprint(

--- a/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
+++ b/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
@@ -1450,7 +1450,7 @@ FROM a
   });
 });
 
-describe('unary operator precedence and grouping', () => {
+describe('binary operator precedence and grouping', () => {
   test('brackets preserved in division numerator', () => {
     const { text } = reprint(
       'FROM index | EVAL aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb / (ccccccccccccccccccccccccccccccccccccccccccccc * 100000000000)'
@@ -1464,6 +1464,73 @@ describe('unary operator precedence and grouping', () => {
         '          (ccccccccccccccccccccccccccccccccccccccccccccc *\n' +
         '          100000000000)'
     );
+  });
+
+  test('division: same-group right operand brackets preserved', () => {
+    assertReprint('ROW a / (b * c)');
+    assertReprint('ROW a / (b / c)');
+    assertReprint('ROW a / (b % c)');
+  });
+
+  test('subtraction: same-group right operand brackets preserved (single-line)', () => {
+    assertReprint('ROW a - (b + c)');
+    assertReprint('ROW a - (b - c)');
+  });
+
+  test('subtraction: same-group right operand brackets preserved (wrapped)', () => {
+    const { text } = reprint(
+      'FROM index | EVAL aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb - (ccccccccccccccccccccccccccccccccccccccccccccc + 100000000000)'
+    );
+
+    expect(text).toBe(
+      'FROM index\n' +
+        '  | EVAL\n' +
+        '      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =\n' +
+        '        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb -\n' +
+        '          (ccccccccccccccccccccccccccccccccccccccccccccc +\n' +
+        '          100000000000)'
+    );
+  });
+
+  test('modulo: same-group right operand brackets preserved', () => {
+    assertReprint('ROW a % (b * c)');
+    assertReprint('ROW a % (b / c)');
+
+    const { text } = reprint(
+      'FROM index | EVAL aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb % (ccccccccccccccccccccccccccccccccccccccccccccc * 100000000000)'
+    );
+
+    expect(text).toBe(
+      'FROM index\n' +
+        '  | EVAL\n' +
+        '      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =\n' +
+        '        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb %\n' +
+        '          (ccccccccccccccccccccccccccccccccccccccccccccc *\n' +
+        '          100000000000)'
+    );
+  });
+
+  test('multiplication: same-group right operand brackets are redundant', () => {
+    assertReprint('ROW a * (b * c)', 'ROW a * b * c');
+    assertReprint('ROW a * (b / c)', 'ROW a * b / c');
+
+    const { text } = reprint(
+      'FROM index | EVAL aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * (ccccccccccccccccccccccccccccccccccccccccccccc / 100000000000)'
+    );
+
+    expect(text).toBe(
+      'FROM index\n' +
+        '  | EVAL\n' +
+        '      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =\n' +
+        '        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *\n' +
+        '          ccccccccccccccccccccccccccccccccccccccccccccc /\n' +
+        '          100000000000'
+    );
+  });
+
+  test('addition: same-group right operand brackets are redundant', () => {
+    assertReprint('ROW a + (b + c)', 'ROW a + b + c');
+    assertReprint('ROW a + (b - c)', 'ROW a + b - c');
   });
 });
 

--- a/src/pretty_print/basic_pretty_printer.ts
+++ b/src/pretty_print/basic_pretty_printer.ts
@@ -442,7 +442,12 @@ export class BasicPrettyPrinter {
 
             const shouldGroup =
               operandGroup &&
-              (operandGroup === BinaryExpressionGroup.unknown || operandGroup < group);
+              (operandGroup === BinaryExpressionGroup.unknown ||
+                operandGroup < group ||
+                // Right operand at same precedence needs parens for /, -, %
+                (index === 1 &&
+                  operandGroup === group &&
+                  (node.name === '/' || node.name === '-' || node.name === '%')));
 
             if (shouldGroup) {
               formatted = `(${formatted})`;

--- a/src/pretty_print/wrapping_pretty_printer.ts
+++ b/src/pretty_print/wrapping_pretty_printer.ts
@@ -166,7 +166,11 @@ export class WrappingPrettyPrinter {
     const groupLeft = binaryExpressionGroup(left);
     const groupRight = binaryExpressionGroup(right);
     const doGroupLeft = groupLeft && groupLeft < group;
-    const doGroupRight = groupRight && groupRight < group;
+    const doGroupRight =
+      groupRight &&
+      (groupRight < group ||
+        // Right operand at same precedence needs parens for /, -, %
+        (groupRight === group && (node.name === '/' || node.name === '-' || node.name === '%')));
     const continueVerticalFlattening = group && inp.flattenBinExpOfType === group;
     const suffix = inp.suffix ?? '';
     const oneArgumentPerLine =


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/esql-js/issues/108

Fixes right-associativity missing bracket issue for operators with same level of precedence.

### Checklist

- [x] Unit tests have been added or updated.
- [x] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax.
- [x] The PR title has the correct [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) label in the title, this is crucial for the correct versioning of this package. Check the following cheat shit.
