### PR TITLE
feat: Support multicommand additions in Composer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ const query = esql`
 
 query.pipe`LIMIT 10`;
 ```
+
+Use `.query` to append multiple piped commands at once:
+
+```ts
+query.query`WHERE status == ${{ status }} | STATS count = COUNT(*) | LIMIT ${{ limit }}`;
+```
 Check also the [`synth`](src/composer/synth/README.md) API for building independent nodes.
 
 

--- a/src/composer/__tests__/composer_query_query.test.ts
+++ b/src/composer/__tests__/composer_query_query.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { esql } from '../esql';
+
+describe('.query``', () => {
+  test('appends multiple commands in one template', () => {
+    const query = esql`FROM index`;
+
+    query.query`WHERE foo > 42 | LIMIT 10`;
+
+    expect(query.print('basic')).toBe('FROM index | WHERE foo > 42 | LIMIT 10');
+  });
+
+  test('appends a single command (equivalent to .pipe)', () => {
+    const query = esql`FROM index`;
+
+    query.query`WHERE foo > 42`;
+
+    expect(query.print('basic')).toBe('FROM index | WHERE foo > 42');
+  });
+
+  test('returns this for chaining', () => {
+    const query = esql`FROM index`;
+    const result = query.query`WHERE foo > 1`;
+
+    expect(result).toBe(query);
+  });
+
+  test('can be chained with .pipe and .query', () => {
+    const query = esql`FROM index`;
+
+    query.query`WHERE a > 1 | EVAL b = a * 2`.pipe`SORT b DESC`.query`LIMIT 100`;
+
+    expect(query.print('basic')).toBe(
+      'FROM index | WHERE a > 1 | EVAL b = a * 2 | SORT b DESC | LIMIT 100'
+    );
+  });
+
+  test('inlines literal values from holes', () => {
+    const query = esql`FROM index`;
+
+    query.query`WHERE foo > ${5} | LIMIT ${10}`;
+
+    expect(query.print('basic')).toBe('FROM index | WHERE foo > 5 | LIMIT 10');
+  });
+
+  test('extracts named params from ${{ }} holes', () => {
+    const query = esql`FROM index`;
+
+    query.query`WHERE status == ${{ status: 'ok' }} | LIMIT ${{ limit: 100 }}`;
+
+    expect(query.toRequest()).toEqual({
+      query: 'FROM index | WHERE status == ?status | LIMIT ?limit',
+      params: [{ status: 'ok' }, { limit: 100 }],
+    });
+  });
+
+  test('${{ }} holes span across commands in the fragment', () => {
+    const query = esql`FROM index`;
+
+    query.query`WHERE a > ${{ threshold: 10 }} | STATS avg = AVG(a) | LIMIT ${{ limit: 50 }}`;
+
+    expect(query.toRequest()).toEqual({
+      query: 'FROM index | WHERE a > ?threshold | STATS avg = AVG(a) | LIMIT ?limit',
+      params: [{ threshold: 10 }, { limit: 50 }],
+    });
+  });
+
+  test('renames colliding params from the fragment', () => {
+    const query = esql`FROM index | WHERE x > ${{ threshold: 1 }}`;
+
+    query.query`WHERE y > ${{ threshold: 2 }} | LIMIT ${{ threshold: 3 }}`;
+
+    expect(query.toRequest()).toEqual({
+      query: 'FROM index | WHERE x > ?threshold | WHERE y > ?p1 | LIMIT ?p2',
+      params: [{ threshold: 1 }, { p1: 2 }, { p2: 3 }],
+    });
+  });
+
+  test('renames colliding params from the fragment - 2', () => {
+    const query = esql`FROM index | WHERE x > ${{ threshold: 1 }} | LIMIT ${{ threshold: 2 }}`;
+
+    query.query`WHERE y > ${{ threshold: 3 }}`;
+
+    expect(query.toRequest()).toEqual({
+      query: 'FROM index | WHERE x > ?threshold | LIMIT ?p1 | WHERE y > ?p2',
+      params: [{ threshold: 1 }, { p1: 2 }, { p2: 3 }],
+    });
+  });
+
+  test('pre-supplied params form', () => {
+    const query = esql`FROM index`;
+
+    query.query({ status: 'ok', limit: 100 })`WHERE status == ?status | LIMIT ?limit`;
+
+    expect(query.toRequest()).toEqual({
+      query: 'FROM index | WHERE status == ?status | LIMIT ?limit',
+      params: [{ status: 'ok' }, { limit: 100 }],
+    });
+  });
+
+  test('string form', () => {
+    const query = esql`FROM index`;
+
+    query.query('WHERE foo > 42 | LIMIT 10');
+
+    expect(query.print('basic')).toBe('FROM index | WHERE foo > 42 | LIMIT 10');
+  });
+
+  test('string form with params', () => {
+    const query = esql`FROM index`;
+
+    query.query('WHERE status == ?status | LIMIT ?limit', { status: 'ok', limit: 100 });
+
+    expect(query.toRequest()).toEqual({
+      query: 'FROM index | WHERE status == ?status | LIMIT ?limit',
+      params: [{ status: 'ok' }, { limit: 100 }],
+    });
+  });
+
+  test('renames colliding params in string form', () => {
+    const query = esql`FROM index | WHERE x > ${{ param: 1 }}`;
+
+    query.query('WHERE y > ?param | LIMIT ?param', { param: 2 });
+
+    expect(query.toRequest()).toEqual({
+      query: 'FROM index | WHERE x > ?param | WHERE y > ?param_1 | LIMIT ?param_1',
+      params: [{ param: 1 }, { param_1: 2 }],
+    });
+  });
+
+  test('throws when fragment starts with a source command', () => {
+    const query = esql`FROM index`;
+
+    expect(() => query.query`FROM other`).toThrow('.query() does not accept source commands');
+  });
+
+  test('throws when fragment starts with ROW', () => {
+    const query = esql`FROM index`;
+
+    expect(() => query.query`ROW a = 1`).toThrow('.query() does not accept source commands');
+  });
+});

--- a/src/composer/composer_query.ts
+++ b/src/composer/composer_query.ts
@@ -8,6 +8,7 @@
 import { printTree } from 'tree-dump';
 import * as synth from './synth';
 import { BasicPrettyPrinter, WrappingPrettyPrinter } from '../pretty_print';
+import { SOURCE_COMMANDS } from '../parser';
 import { composerQuerySymbol, processTemplateHoles, validateParamName } from './util';
 import { Builder } from '../ast/builder';
 import type {
@@ -206,6 +207,123 @@ export class ComposerQuery {
    * ```
    */
   public readonly pipe: QueryCommandTag = this._createCommandTag(synth.cmd);
+
+  /**
+   * Similar to {@linkcode _createCommandTag}, but allows appending multiple
+   * commands at once by parsing a full query fragment.
+   */
+  private readonly _createMultiCommandTag = (
+    synthQueryTag: synth.SynthMethod<ESQLAstQueryExpression>
+  ): QueryCommandTag =>
+    ((templateOrQueryOrParamValues, ...rest: unknown[]) => {
+      const tagOrGeneratorWithParams =
+        (initialParamValues: Record<string, unknown>): QueryCommandTagParametrized =>
+        (templateOrQuery: string | TemplateStringsArray, ...holes: unknown[]) => {
+          const params: Record<string, unknown> = { ...initialParamValues };
+          let queryExpression: ESQLAstQueryExpression;
+
+          if (typeof templateOrQuery === 'string') {
+            const moreParamValues =
+              typeof holes[0] === 'object' && !Array.isArray(holes[0]) ? holes[0] : {};
+
+            Object.assign(params, moreParamValues);
+
+            queryExpression = synthQueryTag(templateOrQuery);
+          } else {
+            if (Array.isArray(holes))
+              processTemplateHoles(holes as ComposerQueryTagHole[], this.params);
+
+            queryExpression = synthQueryTag(
+              templateOrQuery as TemplateStringsArray,
+              ...(holes as synth.SynthTemplateHole[])
+            );
+          }
+
+          const firstCommand = queryExpression.commands[0];
+
+          if (firstCommand && SOURCE_COMMANDS.has(firstCommand.name.toUpperCase())) {
+            throw new Error(
+              `.query() does not accept source commands; use esql\`${firstCommand.name.toUpperCase()} ...\` to start a new query instead.`
+            );
+          }
+
+          for (const [name, value] of Object.entries(params)) {
+            validateParamName(name);
+            const exists = this.params.has(name);
+
+            if (exists) {
+              let newName: string;
+              while (true) {
+                newName = `${name}_${this.params.size}`;
+                if (!this.params.has(newName)) break;
+              }
+
+              this.params.set(newName, value);
+
+              const nodes = Walker.matchAll(queryExpression, {
+                type: 'literal',
+                literalType: 'param',
+                value: name,
+              }) as ESQLNamedParamLiteral[];
+
+              for (const node of nodes) {
+                node.value = newName;
+              }
+            } else {
+              this.params.set(name, value);
+            }
+          }
+
+          for (const command of queryExpression.commands) {
+            this.ast.commands.push(command);
+          }
+
+          if (queryExpression.header?.length) {
+            this.ast.header = this.ast.header || [];
+            this.ast.header.push(...queryExpression.header);
+          }
+
+          return this;
+        };
+
+      if (
+        !!templateOrQueryOrParamValues &&
+        typeof templateOrQueryOrParamValues === 'object' &&
+        !Array.isArray(templateOrQueryOrParamValues)
+      ) {
+        return tagOrGeneratorWithParams(
+          templateOrQueryOrParamValues as Record<string, unknown>
+        ) as QueryCommandTagParametrized;
+      }
+
+      const parametrized = tagOrGeneratorWithParams({});
+
+      if (typeof templateOrQueryOrParamValues === 'string') {
+        return parametrized(templateOrQueryOrParamValues, rest[0] as Record<string, unknown>);
+      } else {
+        return parametrized(
+          templateOrQueryOrParamValues as TemplateStringsArray,
+          ...(rest as ComposerQueryTagHole[])
+        );
+      }
+    }) as QueryCommandTag;
+
+  /**
+   * Appends multiple piped commands to the query in a single template literal.
+   * Unlike {@linkcode pipe}, which accepts exactly one command, this method
+   * parses a full pipeline fragment and appends all of its commands.
+   *
+   * ```typescript
+   * query.query`WHERE status == ${{ status }} | LIMIT ${{ limit }}`;
+   * ```
+   *
+   * All calling forms supported by {@linkcode pipe} are also supported here:
+   * pre-supplied params, string form, and `${{ }}` holes.
+   *
+   * Source commands (`FROM`, `ROW`, etc.) are not allowed in the fragment;
+   * use `esql\`FROM ...\`` to start a new query instead.
+   */
+  public readonly query: QueryCommandTag = this._createMultiCommandTag(synth.qry);
 
   /**
    * Appends a header command to the query. This is used to add commands like `SET`


### PR DESCRIPTION
## Summary

Adds `ComposerQuery#query()` method, which allows adding multiple commands to query during composition:

Start a new query:

```ts
const query = esql `FROM asdf`;
```

Now you can add multiple commands in on `.query` call:

```ts
query.query `WHERE a > 123 | LIMIT 456`;
```

Previously one would need to do add each command separately:

```
query
  .pipe `WHERE a > 123`
  .pipe `LIMIT 456`;
```

### Checklist

- [x] Unit tests have been added or updated.
- [x] The proper documentation has been added or updated.
- [x] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax.
- [x] The PR title has the correct [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) label in the title, this is crucial for the correct versioning of this package. 