### PR TITLE
feat: improve composer `.print()` method

### DIFF
--- a/src/composer/__tests__/composer_query.test.ts
+++ b/src/composer/__tests__/composer_query.test.ts
@@ -44,6 +44,83 @@ ComposerQuery
                └─ literal "2"`);
 });
 
+describe('.print()', () => {
+  describe("'basic' format", () => {
+    test('prints the query on a single line', () => {
+      const query = esql`FROM index | WHERE foo > 42 | STATS count = COUNT(*) BY field1, field2 | LIMIT 10`;
+
+      expect(query.print('basic')).toBe(
+        'FROM index | WHERE foo > 42 | STATS count = COUNT(*) BY field1, field2 | LIMIT 10'
+      );
+    });
+
+    test('forwards options to the basic printer', () => {
+      const query = esql`FROM index | LIMIT 10`;
+
+      expect(query.print('basic', { lowercase: true })).toBe('from index | limit 10');
+    });
+  });
+
+  describe("'wrapping' format", () => {
+    test('is the default format', () => {
+      const query = esql`FROM index | WHERE foo > 42`;
+
+      expect(query.print()).toBe(query.print('wrapping'));
+    });
+
+    test('wraps long commands onto multiple lines', () => {
+      const query = esql`FROM index | STATS count = COUNT(*) BY field_one_long, field_two_long, field_three_long, field_four_long`;
+
+      expect('\n' + query.print('wrapping')).toBe(`
+FROM index
+  | STATS count = COUNT(*)
+        BY field_one_long, field_two_long, field_three_long, field_four_long`);
+    });
+
+    test('forwards options to the wrapping printer', () => {
+      const query = esql`FROM index | STATS count = COUNT(*) BY field_one_long, field_two_long, field_three_long, field_four_long`;
+
+      expect(query.print('wrapping', { wrap: 200 })).toBe(
+        'FROM index | STATS count = COUNT(*) BY field_one_long, field_two_long, field_three_long, field_four_long'
+      );
+    });
+  });
+
+  describe("'pipe-multiline' format", () => {
+    test('keeps a single-command query on one line', () => {
+      const query = esql`FROM index`;
+
+      expect(query.print('pipe-multiline')).toBe('FROM index');
+    });
+
+    test('prints one pipe per line', () => {
+      const query = esql`FROM index | WHERE foo > 42 | STATS count = COUNT(*) BY field1, field2 | LIMIT 10`;
+
+      expect('\n' + query.print('pipe-multiline')).toBe(`
+FROM index
+  | WHERE foo > 42
+  | STATS count = COUNT(*) BY field1, field2
+  | LIMIT 10`);
+    });
+
+    test('does not wrap within commands (long BY clause stays on one line)', () => {
+      const query = esql`FROM index | STATS count = COUNT(*) BY field_one_long, field_two_long, field_three_long, field_four_long`;
+
+      expect('\n' + query.print('pipe-multiline')).toBe(`
+FROM index
+  | STATS count = COUNT(*) BY field_one_long, field_two_long, field_three_long, field_four_long`);
+    });
+
+    test('forwards options while forcing pipe-per-line output', () => {
+      const query = esql`FROM index | LIMIT 10`;
+
+      expect('\n' + query.print('pipe-multiline', { lowercase: true })).toBe(`
+from index
+  | limit 10`);
+    });
+  });
+});
+
 describe('.pipe``', () => {
   test('can add additional commands to the query', () => {
     const query = esql`FROM kibana_ecommerce_index`;

--- a/src/composer/composer_query.ts
+++ b/src/composer/composer_query.ts
@@ -7,6 +7,7 @@
 
 import { printTree } from 'tree-dump';
 import * as synth from './synth';
+import type { BasicPrettyPrinterOptions, WrappingPrettyPrinterOptions } from '../pretty_print';
 import { BasicPrettyPrinter, WrappingPrettyPrinter } from '../pretty_print';
 import { SOURCE_COMMANDS } from '../parser';
 import { composerQuerySymbol, processTemplateHoles, validateParamName } from './util';
@@ -1244,14 +1245,30 @@ export class ComposerQuery {
   /**
    * Prints the query to a string in a specified format.
    *
-   * @param format The format of the printed query. Can be 'wrapping' for a
-   *     more readable format or 'basic' for a single line.
+   * - `wrapping` (default) — readable format that wraps long lines to fit a
+   *   width (80 characters by default).
+   * - `basic` — single line.
+   * - `pipe-multiline` — one pipe (command) per line.
+   *
+   * @param format The format of the printed query.
+   * @param opts Options forwarded to the underlying pretty-printer.
    * @returns The printed query string.
    */
-  public print(format: 'wrapping' | 'basic' = 'wrapping'): string {
-    return format === 'wrapping'
-      ? WrappingPrettyPrinter.print(this.ast)
-      : BasicPrettyPrinter.print(this.ast);
+  public print(format?: 'wrapping', opts?: WrappingPrettyPrinterOptions): string;
+  public print(format: 'basic', opts?: BasicPrettyPrinterOptions): string;
+  public print(format: 'pipe-multiline', opts?: BasicPrettyPrinterOptions): string;
+  public print(
+    format: 'wrapping' | 'basic' | 'pipe-multiline' = 'wrapping',
+    opts?: BasicPrettyPrinterOptions | WrappingPrettyPrinterOptions
+  ): string {
+    switch (format) {
+      case 'pipe-multiline':
+        return BasicPrettyPrinter.print(this.ast, { ...opts, multiline: true });
+      case 'basic':
+        return BasicPrettyPrinter.print(this.ast, opts);
+      default:
+        return WrappingPrettyPrinter.print(this.ast, opts);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/259628

- Adds `"pipe-multiline"` preset for `ComposerQyery#print('pipe-multiline')` - which prints query one command per line.
- Now allows to pass in options for `basic` and `wrapping` presets to customize how the query is printed.

### Checklist

- [x] Unit tests have been added or updated.
