### PR TITLE
feat: IP_LOCATION

### DIFF
--- a/.agents/skills/grammar-sync-update/SKILL.md
+++ b/.agents/skills/grammar-sync-update/SKILL.md
@@ -149,6 +149,14 @@ Add the import for `ESQLAstXxxCommand` at the top of the file.
 
 ### 5. `src/parser/core/cst_to_ast_converter.ts`
 
+Before writing `fromXxxCommand`, grep `cst_to_ast_converter.ts` for an existing private helper. If the grammar shape matches, extend the helper and use a one-liner — don't copy another command's method body.
+
+| Grammar shape | Existing helper |
+|---|---|
+| `qualifiedName = expr` [+ `commandNamedParameters`] | `fromQualifiedNameAssignmentCommand` (`uri_parts`, `registered_domain`, `user_agent`, `ip_location`) |
+| `STATS` / `INLINE STATS` | `fromStatsLikeCommand` |
+| no args | `createCommand` one-liner |
+
 Two additions:
 
 **A — dispatcher** (search for `agent-marker: append new command dispatcher branches here` and add before it):
@@ -379,6 +387,8 @@ Cover:
 |---|---|---|---|
 | `SAMPLE` | none (generic) | none | `sample.test.ts` |
 | `URI_PARTS` | `ESQLAstUriPartsCommand` | `UriPartsCommandVisitorContext` | `uri_parts.test.ts` |
+| `REGISTERED_DOMAIN` | `ESQLAstRegisteredDomainCommand` | `RegisteredDomainCommandVisitorContext` | `registered_domain.test.ts` |
 | `USER_AGENT` | `ESQLAstUserAgentCommand` | `UserAgentCommandVisitorContext` | `user_agent.test.ts` |
+| `IP_LOCATION` | `ESQLAstIpLocationCommand` | `IpLocationCommandVisitorContext` | `ip_location.test.ts` |
 | `CHANGE_POINT` | `ESQLAstChangePointCommand` | none (no typed visitor) | `change_point.test.ts` |
 | `RERANK` | `ESQLAstRerankCommand` | `RerankCommandVisitorContext` | `rerank.test.ts` |

--- a/src/ast/visitor/__tests__/commands.test.ts
+++ b/src/ast/visitor/__tests__/commands.test.ts
@@ -162,6 +162,29 @@ test('can visit REGISTERED_DOMAIN command', () => {
   expect(list).toEqual(['REGISTERED_DOMAIN']);
 });
 
+test('can visit IP_LOCATION command', () => {
+  const { ast } = EsqlQuery.fromSrc(`
+    FROM index
+      | IP_LOCATION geo = client_ip
+  `);
+  const visitor = new Visitor()
+    .on('visitExpression', () => {
+      return null;
+    })
+    .on('visitIpLocationCommand', () => {
+      return 'IP_LOCATION';
+    })
+    .on('visitCommand', () => {
+      return null;
+    })
+    .on('visitQuery', (ctx) => {
+      return [...ctx.visitCommands()].flat();
+    });
+  const list = visitor.visitQuery(ast).flat().filter(Boolean);
+
+  expect(list).toEqual(['IP_LOCATION']);
+});
+
 test('can visit RERANK command', () => {
   const { ast } = EsqlQuery.fromSrc(`
     FROM movies

--- a/src/ast/visitor/contexts.ts
+++ b/src/ast/visitor/contexts.ts
@@ -21,6 +21,7 @@ import type {
   ESQLAstMetricsInfoCommand,
   ESQLAstQueryExpression,
   ESQLAstUserAgentCommand,
+  ESQLAstIpLocationCommand,
   ESQLAstRegisteredDomainCommand,
   ESQLAstRerankCommand,
   ESQLAstTsInfoCommand,
@@ -621,6 +622,12 @@ export class UserAgentCommandVisitorContext<
   Methods extends VisitorMethods = VisitorMethods,
   Data extends SharedData = SharedData,
 > extends CommandVisitorContext<Methods, Data, ESQLAstUserAgentCommand> {}
+
+// IP_LOCATION <qualifiedName> = <primaryExpression> [WITH <map>]
+export class IpLocationCommandVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData,
+> extends CommandVisitorContext<Methods, Data, ESQLAstIpLocationCommand> {}
 
 // Expressions -----------------------------------------------------------------
 

--- a/src/ast/visitor/global_visitor_context.ts
+++ b/src/ast/visitor/global_visitor_context.ts
@@ -15,6 +15,7 @@ import type {
   ESQLAstMetricsInfoCommand,
   ESQLAstQueryExpression,
   ESQLAstUserAgentCommand,
+  ESQLAstIpLocationCommand,
   ESQLAstRegisteredDomainCommand,
   ESQLAstRerankCommand,
   ESQLAstTsInfoCommand,
@@ -367,6 +368,14 @@ export class GlobalVisitorContext<
           input as types.VisitorInput<Methods, 'visitUserAgentCommand'>
         );
       }
+      case 'ip_location': {
+        if (!this.methods.visitIpLocationCommand) break;
+        return this.visitIpLocationCommand(
+          parent,
+          commandNode as ESQLAstIpLocationCommand,
+          input as types.VisitorInput<Methods, 'visitIpLocationCommand'>
+        );
+      }
       case 'dedup': {
         if (!this.methods.visitDedupCommand) break;
         return this.visitDedupCommand(
@@ -691,6 +700,15 @@ export class GlobalVisitorContext<
   ): types.VisitorOutput<Methods, 'visitUserAgentCommand'> {
     const context = new contexts.UserAgentCommandVisitorContext(this, node, parent);
     return this.visitWithSpecificContext('visitUserAgentCommand', context, input);
+  }
+
+  public visitIpLocationCommand(
+    parent: contexts.VisitorContext | null,
+    node: ESQLAstIpLocationCommand,
+    input: types.VisitorInput<Methods, 'visitIpLocationCommand'>
+  ): types.VisitorOutput<Methods, 'visitIpLocationCommand'> {
+    const context = new contexts.IpLocationCommandVisitorContext(this, node, parent);
+    return this.visitWithSpecificContext('visitIpLocationCommand', context, input);
   }
 
   public visitDedupCommand(

--- a/src/ast/visitor/types.ts
+++ b/src/ast/visitor/types.ts
@@ -118,6 +118,7 @@ export type CommandVisitorInput<Methods extends VisitorMethods> = AnyToVoid<
     VisitorInput<Methods, 'visitMetricsInfoCommand'> &
     VisitorInput<Methods, 'visitDedupCommand'> &
     VisitorInput<Methods, 'visitUserAgentCommand'> &
+    VisitorInput<Methods, 'visitIpLocationCommand'> &
     VisitorInput<Methods, 'visitRegisteredDomainCommand'> // agent-marker: append new VisitorInput entries here
 >;
 
@@ -155,6 +156,7 @@ export type CommandVisitorOutput<Methods extends VisitorMethods> =
   | VisitorOutput<Methods, 'visitMetricsInfoCommand'>
   | VisitorOutput<Methods, 'visitDedupCommand'>
   | VisitorOutput<Methods, 'visitUserAgentCommand'>
+  | VisitorOutput<Methods, 'visitIpLocationCommand'>
   | VisitorOutput<Methods, 'visitRegisteredDomainCommand'>; // agent-marker: append new VisitorOutput entries here
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -225,6 +227,11 @@ export interface VisitorMethods<
   visitDedupCommand?: Visitor<contexts.DedupCommandVisitorContext<Visitors, Data>, any, any>;
   visitUserAgentCommand?: Visitor<
     contexts.UserAgentCommandVisitorContext<Visitors, Data>,
+    any,
+    any
+  >;
+  visitIpLocationCommand?: Visitor<
+    contexts.IpLocationCommandVisitorContext<Visitors, Data>,
     any,
     any
   >;

--- a/src/parser/__tests__/ip_location.test.ts
+++ b/src/parser/__tests__/ip_location.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EsqlQuery } from '../../composer/query';
+import { Walker } from '../../ast/walker';
+import type { ESQLAstIpLocationCommand, ESQLAstQueryExpression } from '../../types';
+
+describe('IP_LOCATION', () => {
+  const getIpLocation = (ast: ESQLAstQueryExpression): ESQLAstIpLocationCommand =>
+    Walker.match(ast, {
+      type: 'command',
+      name: 'ip_location',
+    }) as ESQLAstIpLocationCommand;
+
+  it('parses target = expression', () => {
+    const src = `FROM web_logs | IP_LOCATION geo = client_ip`;
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const cmd = getIpLocation(ast);
+
+    expect(errors).toHaveLength(0);
+    expect(cmd).toMatchObject({
+      type: 'command',
+      name: 'ip_location',
+      incomplete: false,
+      targetField: { type: 'column', name: 'geo' },
+      expression: { type: 'column', name: 'client_ip' },
+    });
+    expect(cmd.args[0]).toMatchObject({
+      type: 'function',
+      subtype: 'binary-expression',
+      name: '=',
+    });
+  });
+
+  it('parses optional WITH { database: "..." }', () => {
+    const src = `FROM web_logs | IP_LOCATION geo = client_ip WITH { "database": "GeoLite2-City.mmdb" }`;
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const cmd = getIpLocation(ast);
+
+    expect(errors).toHaveLength(0);
+    expect(cmd.namedParameters).toMatchObject({
+      type: 'map',
+      entries: [
+        {
+          type: 'map-entry',
+          key: { type: 'literal', valueUnquoted: 'database' },
+          value: { type: 'literal', valueUnquoted: 'GeoLite2-City.mmdb' },
+        },
+      ],
+    });
+  });
+
+  it('marks incomplete when expression is missing', () => {
+    const { ast, errors } = EsqlQuery.fromSrc(`FROM index | IP_LOCATION geo =`);
+    const cmd = getIpLocation(ast);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(cmd).toMatchObject({
+      name: 'ip_location',
+      incomplete: true,
+      targetField: { type: 'column', name: 'geo' },
+      expression: { type: 'unknown', incomplete: true },
+    });
+  });
+
+  it('errors on just the command keyword', () => {
+    const { ast, errors } = EsqlQuery.fromSrc(`FROM index | IP_LOCATION`);
+    const cmd = getIpLocation(ast);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(cmd).toMatchObject({
+      name: 'ip_location',
+      incomplete: true,
+      targetField: { type: 'column', name: '', incomplete: true },
+    });
+    expect(cmd.expression).toBeUndefined();
+  });
+});

--- a/src/parser/core/cst_to_ast_converter.ts
+++ b/src/parser/core/cst_to_ast_converter.ts
@@ -545,6 +545,12 @@ export class CstToAstConverter {
       return this.fromUserAgentCommand(userAgentCommandCtx);
     }
 
+    const ipLocationCommandCtx = ctx.ipLocationCommand();
+
+    if (ipLocationCommandCtx) {
+      return this.fromIpLocationCommand(ipLocationCommandCtx);
+    }
+
     const dedupCommandCtx = ctx.dedupCommand();
 
     if (dedupCommandCtx) {
@@ -2323,12 +2329,20 @@ export class CstToAstConverter {
   }
 
   private fromQualifiedNameAssignmentCommand<
-    TName extends 'registered_domain' | 'uri_parts',
+    TName extends 'registered_domain' | 'uri_parts' | 'user_agent' | 'ip_location',
     TCommand extends ast.ESQLCommand<TName> & {
       targetField: ast.ESQLColumn;
       expression?: ast.ESQLSingleAstItem;
+      namedParameters?: ast.ESQLSingleAstItem;
     },
-  >(name: TName, ctx: cst.RegisteredDomainCommandContext | cst.UriPartsCommandContext): TCommand {
+  >(
+    name: TName,
+    ctx:
+      | cst.RegisteredDomainCommandContext
+      | cst.UriPartsCommandContext
+      | cst.UserAgentCommandContext
+      | cst.IpLocationCommandContext
+  ): TCommand {
     const command = this.createCommand<TName, TCommand>(name, ctx);
     const qualifiedNameCtx = ctx.qualifiedName();
 
@@ -2340,6 +2354,7 @@ export class CstToAstConverter {
       command.expression = expression;
 
       if (expression.incomplete || expression.type === 'unknown') {
+        expression.incomplete = true;
         command.incomplete = true;
       }
 
@@ -2358,6 +2373,17 @@ export class CstToAstConverter {
       command.targetField = targetField;
       command.incomplete = true;
       command.args.push(targetField);
+    }
+
+    if (ctx instanceof cst.UserAgentCommandContext || ctx instanceof cst.IpLocationCommandContext) {
+      const withOption = this.fromOptionalNamedParametersWithOption(ctx.commandNamedParameters());
+
+      if (withOption) {
+        command.args.push(withOption);
+        command.namedParameters = withOption.args[0] as ast.ESQLSingleAstItem;
+      }
+
+      command.incomplete ||= withOption?.incomplete ?? false;
     }
 
     return command;
@@ -2380,65 +2406,13 @@ export class CstToAstConverter {
   // --------------------------------------------------------------- USER_AGENT
 
   private fromUserAgentCommand(ctx: cst.UserAgentCommandContext): ast.ESQLAstUserAgentCommand {
-    const args: ast.ESQLAstItem[] = [];
+    return this.fromQualifiedNameAssignmentCommand('user_agent', ctx);
+  }
 
-    const qualifiedNameCtx = ctx.qualifiedName();
-    let targetField: ast.ESQLColumn | undefined;
-    let expression: ast.ESQLAstExpression | undefined;
+  // --------------------------------------------------------------- IP_LOCATION
 
-    if (qualifiedNameCtx && ctx.ASSIGN()) {
-      targetField = this.toColumn(qualifiedNameCtx);
-      expression = this.fromPrimaryExpressionStrict(ctx.primaryExpression());
-
-      const assignment = this.toFunction(
-        ctx.ASSIGN().getText(),
-        ctx,
-        undefined,
-        'binary-expression'
-      );
-      assignment.args.push(targetField, expression);
-      assignment.location = this.extendLocationToArgs(assignment);
-      args.push(assignment);
-    } else if (qualifiedNameCtx) {
-      targetField = this.toColumn(qualifiedNameCtx);
-      args.push(targetField);
-    }
-
-    const withOption = this.fromOptionalNamedParametersWithOption(ctx.commandNamedParameters());
-    if (withOption) {
-      args.push(withOption);
-    }
-
-    const namedParameters = withOption?.args[0] as ast.ESQLSingleAstItem | undefined;
-
-    const command = this.createCommand<'user_agent', ast.ESQLAstUserAgentCommand>(
-      'user_agent',
-      ctx,
-      {
-        args,
-        ...(namedParameters ? { namedParameters } : {}),
-      }
-    );
-
-    if (targetField) {
-      command.targetField = targetField;
-    }
-    if (expression) {
-      command.expression = expression;
-    }
-
-    if (qualifiedNameCtx && ctx.ASSIGN()) {
-      if (expression && (expression.incomplete || expression.type === 'unknown')) {
-        expression.incomplete = true;
-        command.incomplete = true;
-      }
-    } else if (qualifiedNameCtx) {
-      command.incomplete = true;
-    }
-
-    command.incomplete ||= withOption?.incomplete ?? false;
-
-    return command;
+  private fromIpLocationCommand(ctx: cst.IpLocationCommandContext): ast.ESQLAstIpLocationCommand {
+    return this.fromQualifiedNameAssignmentCommand('ip_location', ctx);
   }
 
   // -------------------------------------------------------------- expressions

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type ESQLAstCommand =
   | ESQLAstTsInfoCommand
   | ESQLAstMetricsInfoCommand
   | ESQLAstUserAgentCommand
+  | ESQLAstIpLocationCommand
   | ESQLAstRegisteredDomainCommand;
 
 export type ESQLAstAllCommands = ESQLAstCommand | ESQLAstHeaderCommand;
@@ -172,6 +173,12 @@ export interface ESQLAstTsInfoCommand extends ESQLCommand<'ts_info'> {}
 export interface ESQLAstMetricsInfoCommand extends ESQLCommand<'metrics_info'> {}
 
 export interface ESQLAstUserAgentCommand extends ESQLCommand<'user_agent'> {
+  targetField: ESQLColumn;
+  expression?: ESQLAstExpression;
+  namedParameters?: ESQLSingleAstItem;
+}
+
+export interface ESQLAstIpLocationCommand extends ESQLCommand<'ip_location'> {
   targetField: ESQLColumn;
   expression?: ESQLAstExpression;
   namedParameters?: ESQLSingleAstItem;


### PR DESCRIPTION
## Summary

Probably we can add to the `skill.md` something like

```Before writing `fromXxxCommand`, grep `cst_to_ast_converter.ts` for an existing private helper. If the grammar shape matches, extend the helper and use a one-liner — don't copy another command's method body.```