### PR TITLE
feat: make parens parsing in ES|QL opt-in

### DIFF
--- a/.changeset/strong-parts-share.md
+++ b/.changeset/strong-parts-share.md
@@ -1,0 +1,5 @@
+---
+'@elastic/esql': minor
+---
+
+Add a `withParens` parse option to opt out of preserving redundant expression parentheses in the AST. Defaults to `true` (current behavior), set it to `false` to drop parens around expressions, matching the behavior before explicit parens parsing.

--- a/.changeset/strong-parts-share.md
+++ b/.changeset/strong-parts-share.md
@@ -2,4 +2,4 @@
 '@elastic/esql': minor
 ---
 
-Add a `withParens` parse option to opt out of preserving redundant expression parentheses in the AST. Defaults to `true` (current behavior), set it to `false` to drop parens around expressions, matching the behavior before explicit parens parsing.
+Add a `withParens` parse option to opt into preserving redundant expression parentheses in the AST. Defaults to `false` (parens around expressions are dropped, producing a normalized AST for validation). Set it to `true`, mainly for pretty-printing, to keep the parentheses so they round-trip.

--- a/packages/esql/src/parser/__tests__/binary_expression_grouping.test.ts
+++ b/packages/esql/src/parser/__tests__/binary_expression_grouping.test.ts
@@ -43,50 +43,49 @@ const assertDifferentAst = (src1: string, src2: string) => {
 
 describe('binary operator precedence', () => {
   it('AND has higher precedence than OR', () => {
-    // With faithful round-trip, explicit parens produce a different AST than implicit precedence
-    assertDifferentAst('FROM a | WHERE a AND b OR c', 'FROM a | WHERE (a AND b) OR c');
-    assertDifferentAst('FROM a | WHERE a OR b OR c', 'FROM a | WHERE (a OR b) OR c');
-    assertDifferentAst('FROM a | WHERE a AND b AND c', 'FROM a | WHERE (a AND b) AND c');
+    assertSameAst('FROM a | WHERE a AND b OR c', 'FROM a | WHERE (a AND b) OR c');
+    assertSameAst('FROM a | WHERE a OR b OR c', 'FROM a | WHERE (a OR b) OR c');
+    assertSameAst('FROM a | WHERE a AND b AND c', 'FROM a | WHERE (a AND b) AND c');
     assertDifferentAst('FROM a | WHERE a OR b AND c', 'FROM a | WHERE (a OR b) AND c');
   });
 
   it('LIKE (regex) has higher precedence than AND', () => {
-    assertDifferentAst('FROM a | WHERE a LIKE "b" OR c', 'FROM a | WHERE (a LIKE "b") OR c');
+    assertSameAst('FROM a | WHERE a LIKE "b" OR c', 'FROM a | WHERE (a LIKE "b") OR c');
     assertDifferentAst('FROM a | WHERE a AND b LIKE "c"', 'FROM a | WHERE (a AND b) LIKE "c"');
   });
 
   it('comparison has higher precedence than AND', () => {
-    assertDifferentAst('FROM a | WHERE a AND b < c', 'FROM a | WHERE a AND (b < c)');
-    assertDifferentAst('FROM a | WHERE a < b AND c', 'FROM a | WHERE (a < b) AND c');
+    assertSameAst('FROM a | WHERE a AND b < c', 'FROM a | WHERE a AND (b < c)');
+    assertSameAst('FROM a | WHERE a < b AND c', 'FROM a | WHERE (a < b) AND c');
     assertDifferentAst('FROM a | WHERE a AND b < c', 'FROM a | WHERE (a AND b) < c');
     assertDifferentAst('FROM a | WHERE a < b AND c', 'FROM a | WHERE a < (b AND c)');
   });
 
   it('addition has higher precedence than comparison', () => {
-    assertDifferentAst('FROM a | WHERE a > b + c', 'FROM a | WHERE a > (b + c)');
-    assertDifferentAst('FROM a | WHERE a + b > c', 'FROM a | WHERE (a + b) > c');
+    assertSameAst('FROM a | WHERE a > b + c', 'FROM a | WHERE a > (b + c)');
+    assertSameAst('FROM a | WHERE a + b > c', 'FROM a | WHERE (a + b) > c');
     assertDifferentAst('FROM a | WHERE a > b + c', 'FROM a | WHERE (a > b) + c');
     assertDifferentAst('FROM a | WHERE a + b > c', 'FROM a | WHERE a + (b > c)');
   });
 
   it('addition has higher precedence than AND (and LIKE)', () => {
-    assertDifferentAst('FROM a | WHERE a + b AND c', 'FROM a | WHERE (a + b) AND c');
+    assertSameAst('FROM a | WHERE a + b AND c', 'FROM a | WHERE (a + b) AND c');
     // TODO: this test should work once right side of LIKE does not return a list of "single items"
-    // assertDifferentAst('FROM a | WHERE a + b LIKE "c"', 'FROM a | WHERE (a + b) LIKE "c"');
-    assertDifferentAst('FROM a | WHERE a AND b + c', 'FROM a | WHERE a AND (b + c)');
+    // assertSameAst('FROM a | WHERE a + b LIKE "c"', 'FROM a | WHERE (a + b) LIKE "c"');
+    assertSameAst('FROM a | WHERE a AND b + c', 'FROM a | WHERE a AND (b + c)');
     assertDifferentAst('FROM a | WHERE a + b AND c', 'FROM a | WHERE a + (b AND c)');
     assertDifferentAst('FROM a | WHERE a AND b + c', 'FROM a | WHERE (a AND b) + c');
   });
 
   it('multiplication has higher precedence than addition', () => {
-    assertDifferentAst('FROM a | WHERE a * b + c', 'FROM a | WHERE (a * b) + c');
-    assertDifferentAst('FROM a | WHERE a + b * c', 'FROM a | WHERE a + (b * c)');
+    assertSameAst('FROM a | WHERE a * b + c', 'FROM a | WHERE (a * b) + c');
+    assertSameAst('FROM a | WHERE a + b * c', 'FROM a | WHERE a + (b * c)');
     assertDifferentAst('FROM a | WHERE a * b + c', 'FROM a | WHERE a * (b + c)');
     assertDifferentAst('FROM a | WHERE a + b * c', 'FROM a | WHERE (a + b) * c');
   });
 
   it('grouping addition in comparison is not necessary', () => {
-    assertDifferentAst(
+    assertSameAst(
       'FROM a | EVAL key = CASE(timestamp < t - 1 hour AND timestamp > t - 2 hour)',
       'FROM a | EVAL key = CASE(timestamp < (t - 1 hour) AND timestamp > (t - 2 hour))'
     );

--- a/packages/esql/src/parser/__tests__/boolean_expressions.test.ts
+++ b/packages/esql/src/parser/__tests__/boolean_expressions.test.ts
@@ -26,11 +26,8 @@ describe('Column Identifier Expressions', () => {
     const expression = root.commands[0].args[0];
 
     expect(expression).toMatchObject({
-      type: 'parens',
-      child: {
-        type: 'literal',
-        value: 123,
-      },
+      type: 'literal',
+      value: 123,
     });
   });
 
@@ -115,11 +112,8 @@ describe('Column Identifier Expressions', () => {
       name: 'not',
       args: [
         {
-          type: 'parens',
-          child: {
-            type: 'function',
-            name: 'and',
-          },
+          type: 'function',
+          name: 'and',
         },
       ],
     });
@@ -349,38 +343,32 @@ describe('Column Identifier Expressions', () => {
       name: 'or',
       args: [
         {
-          type: 'parens',
-          child: {
-            type: 'function',
-            name: 'and',
-            args: [
-              {
-                type: 'function',
-                name: '>',
-              },
-              {
-                type: 'function',
-                name: '<',
-              },
-            ],
-          },
+          type: 'function',
+          name: 'and',
+          args: [
+            {
+              type: 'function',
+              name: '>',
+            },
+            {
+              type: 'function',
+              name: '<',
+            },
+          ],
         },
         {
-          type: 'parens',
-          child: {
-            type: 'function',
-            name: 'and',
-            args: [
-              {
-                type: 'function',
-                name: '==',
-              },
-              {
-                type: 'function',
-                name: 'not',
-              },
-            ],
-          },
+          type: 'function',
+          name: 'and',
+          args: [
+            {
+              type: 'function',
+              name: '==',
+            },
+            {
+              type: 'function',
+              name: 'not',
+            },
+          ],
         },
       ],
     });

--- a/packages/esql/src/parser/__tests__/join.test.ts
+++ b/packages/esql/src/parser/__tests__/join.test.ts
@@ -446,47 +446,44 @@ describe('<TYPE> JOIN command', () => {
               name: 'on',
               args: [
                 {
-                  type: 'parens',
-                  child: {
-                    type: 'function',
-                    name: 'or',
-                    args: [
-                      {
-                        type: 'function',
-                        name: '<',
-                        args: [
-                          {
-                            type: 'column',
-                            name: 'right_value',
-                          },
-                          {
-                            type: 'literal',
-                            value: 5000,
-                          },
-                        ],
-                      },
-                      {
-                        type: 'function',
-                        name: 'not',
-                        args: [
-                          {
-                            type: 'function',
-                            name: '==',
-                            args: [
-                              {
-                                type: 'column',
-                                name: 'left_id',
-                              },
-                              {
-                                type: 'column',
-                                name: 'right_id',
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
+                  type: 'function',
+                  name: 'or',
+                  args: [
+                    {
+                      type: 'function',
+                      name: '<',
+                      args: [
+                        {
+                          type: 'column',
+                          name: 'right_value',
+                        },
+                        {
+                          type: 'literal',
+                          value: 5000,
+                        },
+                      ],
+                    },
+                    {
+                      type: 'function',
+                      name: 'not',
+                      args: [
+                        {
+                          type: 'function',
+                          name: '==',
+                          args: [
+                            {
+                              type: 'column',
+                              name: 'left_id',
+                            },
+                            {
+                              type: 'column',
+                              name: 'right_id',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
                 },
               ],
             },

--- a/packages/esql/src/parser/__tests__/parens.test.ts
+++ b/packages/esql/src/parser/__tests__/parens.test.ts
@@ -9,11 +9,76 @@ import { Parser } from '..';
 import type { ESQLParens } from '../../types';
 import { BasicPrettyPrinter } from '../../pretty_print';
 
-const parse = (src: string) => Parser.parse(src).root;
+const parse = (src: string) => Parser.parse(src, { withParens: true }).root;
 const firstArg = (src: string) => parse(src).commands[0].args[0];
 const reprint = (src: string) => BasicPrettyPrinter.print(parse(src));
 
-describe('parenthesized expression parsing', () => {
+describe('expression parens are dropped by default', () => {
+  const firstArgDefault = (src: string) => Parser.parse(src).root.commands[0].args[0];
+
+  it('does not wrap a literal in ESQLParens', () => {
+    expect(firstArgDefault('ROW (123)')).toMatchObject({
+      type: 'literal',
+      value: 123,
+    });
+  });
+
+  it('does not wrap a column reference in ESQLParens', () => {
+    expect(firstArgDefault('ROW (a)')).toMatchObject({
+      type: 'column',
+      name: 'a',
+    });
+  });
+
+  it('drops redundant parens around a binary expression', () => {
+    expect(firstArgDefault('ROW (a + b)')).toMatchObject({
+      type: 'function',
+      name: '+',
+    });
+  });
+
+  it('drops nested redundant parens', () => {
+    expect(firstArgDefault('ROW ((a))')).toMatchObject({
+      type: 'column',
+      name: 'a',
+    });
+  });
+
+  it('preserves operand structure without parens nodes', () => {
+    expect(firstArgDefault('ROW (a + b) * c')).toMatchObject({
+      type: 'function',
+      name: '*',
+      args: [
+        { type: 'function', name: '+' },
+        { type: 'column', name: 'c' },
+      ],
+    });
+  });
+
+  it('NOT (expr) argument is unwrapped', () => {
+    expect(firstArgDefault('ROW NOT (a AND b)')).toMatchObject({
+      type: 'function',
+      name: 'not',
+      args: [{ type: 'function', name: 'and' }],
+    });
+  });
+
+  it('produces the same AST as the equivalent paren-free source', () => {
+    const strip = (root: unknown) =>
+      JSON.parse(
+        JSON.stringify(root, (k, v) =>
+          ['text', 'location', 'incomplete'].includes(k) ? undefined : v
+        )
+      );
+
+    const withRedundantParens = strip(Parser.parse('ROW a + (b * c)').root);
+    const parenFree = strip(Parser.parse('ROW a + b * c').root);
+
+    expect(withRedundantParens).toEqual(parenFree);
+  });
+});
+
+describe('expression parens preserved with { withParens: true }', () => {
   describe('AST structure', () => {
     it('wraps a literal in ESQLParens', () => {
       expect(firstArg('ROW (123)')).toMatchObject({
@@ -134,75 +199,9 @@ describe('parenthesized expression parsing', () => {
     });
   });
 
-  describe('withParens: false (opt-out)', () => {
-    const firstArgNoParens = (src: string) =>
-      Parser.parse(src, { withParens: false }).root.commands[0].args[0];
-
-    it('does not wrap a literal in ESQLParens', () => {
-      expect(firstArgNoParens('ROW (123)')).toMatchObject({
-        type: 'literal',
-        value: 123,
-      });
-    });
-
-    it('does not wrap a column reference in ESQLParens', () => {
-      expect(firstArgNoParens('ROW (a)')).toMatchObject({
-        type: 'column',
-        name: 'a',
-      });
-    });
-
-    it('drops redundant parens around a binary expression', () => {
-      expect(firstArgNoParens('ROW (a + b)')).toMatchObject({
-        type: 'function',
-        name: '+',
-      });
-    });
-
-    it('drops nested redundant parens', () => {
-      expect(firstArgNoParens('ROW ((a))')).toMatchObject({
-        type: 'column',
-        name: 'a',
-      });
-    });
-
-    it('preserves operand structure without parens nodes', () => {
-      expect(firstArgNoParens('ROW (a + b) * c')).toMatchObject({
-        type: 'function',
-        name: '*',
-        args: [
-          { type: 'function', name: '+' },
-          { type: 'column', name: 'c' },
-        ],
-      });
-    });
-
-    it('NOT (expr) argument is unwrapped', () => {
-      expect(firstArgNoParens('ROW NOT (a AND b)')).toMatchObject({
-        type: 'function',
-        name: 'not',
-        args: [{ type: 'function', name: 'and' }],
-      });
-    });
-
-    it('matches the AST produced for the equivalent paren-free source', () => {
-      const strip = (root: unknown) =>
-        JSON.parse(
-          JSON.stringify(root, (k, v) =>
-            ['text', 'location', 'incomplete'].includes(k) ? undefined : v
-          )
-        );
-
-      const without = strip(Parser.parse('ROW a + (b * c)', { withParens: false }).root);
-      const natural = strip(Parser.parse('ROW a + b * c').root);
-
-      expect(without).toEqual(natural);
-    });
-  });
-
   describe('parens produce structurally distinct ASTs', () => {
     const strip = (src: string) => {
-      const { root } = Parser.parse(src);
+      const { root } = Parser.parse(src, { withParens: true });
 
       return JSON.parse(
         JSON.stringify(root, (k, v) =>

--- a/packages/esql/src/parser/__tests__/parens.test.ts
+++ b/packages/esql/src/parser/__tests__/parens.test.ts
@@ -134,6 +134,72 @@ describe('parenthesized expression parsing', () => {
     });
   });
 
+  describe('withParens: false (opt-out)', () => {
+    const firstArgNoParens = (src: string) =>
+      Parser.parse(src, { withParens: false }).root.commands[0].args[0];
+
+    it('does not wrap a literal in ESQLParens', () => {
+      expect(firstArgNoParens('ROW (123)')).toMatchObject({
+        type: 'literal',
+        value: 123,
+      });
+    });
+
+    it('does not wrap a column reference in ESQLParens', () => {
+      expect(firstArgNoParens('ROW (a)')).toMatchObject({
+        type: 'column',
+        name: 'a',
+      });
+    });
+
+    it('drops redundant parens around a binary expression', () => {
+      expect(firstArgNoParens('ROW (a + b)')).toMatchObject({
+        type: 'function',
+        name: '+',
+      });
+    });
+
+    it('drops nested redundant parens', () => {
+      expect(firstArgNoParens('ROW ((a))')).toMatchObject({
+        type: 'column',
+        name: 'a',
+      });
+    });
+
+    it('preserves operand structure without parens nodes', () => {
+      expect(firstArgNoParens('ROW (a + b) * c')).toMatchObject({
+        type: 'function',
+        name: '*',
+        args: [
+          { type: 'function', name: '+' },
+          { type: 'column', name: 'c' },
+        ],
+      });
+    });
+
+    it('NOT (expr) argument is unwrapped', () => {
+      expect(firstArgNoParens('ROW NOT (a AND b)')).toMatchObject({
+        type: 'function',
+        name: 'not',
+        args: [{ type: 'function', name: 'and' }],
+      });
+    });
+
+    it('matches the AST produced for the equivalent paren-free source', () => {
+      const strip = (root: unknown) =>
+        JSON.parse(
+          JSON.stringify(root, (k, v) =>
+            ['text', 'location', 'incomplete'].includes(k) ? undefined : v
+          )
+        );
+
+      const without = strip(Parser.parse('ROW a + (b * c)', { withParens: false }).root);
+      const natural = strip(Parser.parse('ROW a + b * c').root);
+
+      expect(without).toEqual(natural);
+    });
+  });
+
   describe('parens produce structurally distinct ASTs', () => {
     const strip = (src: string) => {
       const { root } = Parser.parse(src);

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -2602,7 +2602,7 @@ export class CstToAstConverter {
     } else if (ctx instanceof cst.ParenthesizedExpressionContext) {
       const inner = this.fromBooleanExpressionToExpressionOrUnknown(ctx.booleanExpression());
 
-      if (this.parser.options.withParens === false) {
+      if (this.parser.options.withParens !== true) {
         return inner;
       }
 

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -2602,6 +2602,10 @@ export class CstToAstConverter {
     } else if (ctx instanceof cst.ParenthesizedExpressionContext) {
       const inner = this.fromBooleanExpressionToExpressionOrUnknown(ctx.booleanExpression());
 
+      if (this.parser.options.withParens === false) {
+        return inner;
+      }
+
       return Builder.expression.parens(inner, {
         text: ctx.getText(),
         location: getPosition(ctx.start, ctx.stop),

--- a/packages/esql/src/parser/core/parser.ts
+++ b/packages/esql/src/parser/core/parser.ts
@@ -34,6 +34,18 @@ export interface ParseOptions {
    * comments and whitespace.
    */
   withFormatting?: boolean;
+
+  /**
+   * Whether to preserve user's parentheses around expressions as explicit
+   * *ParensExpression* nodes in the AST. Defaults to `true`. When set to
+   * `false`, redundant parentheses around expressions are dropped (the inner
+   * expression is returned directly), matching the behavior before explicit
+   * parens parsing was introduced.
+   *
+   * Note: parentheses with structural meaning (e.g. around sub-queries or
+   * FORK branches) are always preserved, regardless of this option.
+   */
+  withParens?: boolean;
 }
 
 export interface ParseResult<T extends ESQLProperNode = ESQLAstQueryExpression> {

--- a/packages/esql/src/parser/core/parser.ts
+++ b/packages/esql/src/parser/core/parser.ts
@@ -37,10 +37,13 @@ export interface ParseOptions {
 
   /**
    * Whether to preserve user's parentheses around expressions as explicit
-   * *ParensExpression* nodes in the AST. Defaults to `true`. When set to
-   * `false`, redundant parentheses around expressions are dropped (the inner
-   * expression is returned directly), matching the behavior before explicit
-   * parens parsing was introduced.
+   * *ParensExpression* nodes in the AST. Defaults to `false`, in which case
+   * redundant parentheses around expressions are dropped (the inner expression
+   * is returned directly). This is the default because consumers like
+   * validation expect a normalized AST without redundant parens.
+   *
+   * Set to `true` to keep the parentheses; this is mainly useful for
+   * pretty-printing, where the original parentheses should round-trip.
    *
    * Note: parentheses with structural meaning (e.g. around sub-queries or
    * FORK branches) are always preserved, regardless of this option.

--- a/packages/esql/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/packages/esql/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -15,7 +15,7 @@ import type {
 import { BasicPrettyPrinter } from '../basic_pretty_printer';
 
 const reprint = (src: string, opts?: BasicPrettyPrinterOptions) => {
-  const { root } = Parser.parse(src);
+  const { root } = Parser.parse(src, { withParens: true });
   const text = BasicPrettyPrinter.print(root, opts);
 
   // console.log(JSON.stringify(root, null, 2));
@@ -1026,7 +1026,7 @@ describe('single line query', () => {
 
 describe('multiline query', () => {
   const multiline = (src: string, opts?: BasicPrettyPrinterMultilineOptions) => {
-    const { root } = Parser.parse(src);
+    const { root } = Parser.parse(src, { withParens: true });
     const text = BasicPrettyPrinter.multiline(root, opts);
 
     // console.log(JSON.stringify(ast, null, 2));

--- a/packages/esql/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
+++ b/packages/esql/src/pretty_print/__tests__/wrapping_pretty_printer.test.ts
@@ -12,7 +12,7 @@ import type { WrappingPrettyPrinterOptions } from '../wrapping_pretty_printer';
 import { WrappingPrettyPrinter } from '../wrapping_pretty_printer';
 
 const reprint = (src: string, opts?: WrappingPrettyPrinterOptions) => {
-  const { root } = Parser.parse(src);
+  const { root } = Parser.parse(src, { withParens: true });
   const text = WrappingPrettyPrinter.print(root, opts);
 
   // console.log(JSON.stringify(root.commands, null, 2));


### PR DESCRIPTION
## Summary

- Introduces opt-in `{withParens: boolean}` flag, `false` by default, when `true` parses verbatim all `()` parens in expressions, even if not strictly necessary. Needed for pretty-printing to preserve user formatting.

### Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Unit tests have been added or updated.
- [x] The proper documentation has been added or updated.
- [x] A changeset has been added (`yarn changeset`) if this change should be released. You choose the bump level (`patch` / `minor` / `major`) there — see [docs/RELEASE.md](../docs/RELEASE.md).
- [x] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax and selected a `major` bump in the changeset.
- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format (`feat`, `fix`, `refactor`, `perf`, `build`, `docs`, `chore`, `revert`) — this is enforced by CI and keeps the history and changelog clean. Note: the title no longer drives versioning; the changeset does.
