### PR TITLE
feat: HIGHLIGHT command

### DIFF
--- a/.changeset/highlight-command.md
+++ b/.changeset/highlight-command.md
@@ -1,0 +1,5 @@
+---
+'@elastic/esql': minor
+---
+
+Add support for the `HIGHLIGHT` command in the ES|QL parser and AST.

--- a/packages/esql/src/ast/visitor/contexts.ts
+++ b/packages/esql/src/ast/visitor/contexts.ts
@@ -23,6 +23,7 @@ import type {
   ESQLAstUserAgentCommand,
   ESQLAstIpLocationCommand,
   ESQLAstRegisteredDomainCommand,
+  ESQLAstHighlightCommand,
   ESQLAstRerankCommand,
   ESQLAstTsInfoCommand,
   ESQLAstUriPartsCommand,
@@ -628,6 +629,12 @@ export class IpLocationCommandVisitorContext<
   Methods extends VisitorMethods = VisitorMethods,
   Data extends SharedData = SharedData,
 > extends CommandVisitorContext<Methods, Data, ESQLAstIpLocationCommand> {}
+
+// HIGHLIGHT <string> ON <qualifiedNames> [WITH <map>]
+export class HighlightCommandVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData,
+> extends CommandVisitorContext<Methods, Data, ESQLAstHighlightCommand> {}
 
 // Expressions -----------------------------------------------------------------
 

--- a/packages/esql/src/ast/visitor/global_visitor_context.ts
+++ b/packages/esql/src/ast/visitor/global_visitor_context.ts
@@ -17,6 +17,7 @@ import type {
   ESQLAstUserAgentCommand,
   ESQLAstIpLocationCommand,
   ESQLAstRegisteredDomainCommand,
+  ESQLAstHighlightCommand,
   ESQLAstRerankCommand,
   ESQLAstTsInfoCommand,
   ESQLAstUriPartsCommand,
@@ -376,6 +377,14 @@ export class GlobalVisitorContext<
           input as types.VisitorInput<Methods, 'visitIpLocationCommand'>
         );
       }
+      case 'highlight': {
+        if (!this.methods.visitHighlightCommand) break;
+        return this.visitHighlightCommand(
+          parent,
+          commandNode as ESQLAstHighlightCommand,
+          input as types.VisitorInput<Methods, 'visitHighlightCommand'>
+        );
+      }
       case 'dedup': {
         if (!this.methods.visitDedupCommand) break;
         return this.visitDedupCommand(
@@ -709,6 +718,15 @@ export class GlobalVisitorContext<
   ): types.VisitorOutput<Methods, 'visitIpLocationCommand'> {
     const context = new contexts.IpLocationCommandVisitorContext(this, node, parent);
     return this.visitWithSpecificContext('visitIpLocationCommand', context, input);
+  }
+
+  public visitHighlightCommand(
+    parent: contexts.VisitorContext | null,
+    node: ESQLAstHighlightCommand,
+    input: types.VisitorInput<Methods, 'visitHighlightCommand'>
+  ): types.VisitorOutput<Methods, 'visitHighlightCommand'> {
+    const context = new contexts.HighlightCommandVisitorContext(this, node, parent);
+    return this.visitWithSpecificContext('visitHighlightCommand', context, input);
   }
 
   public visitDedupCommand(

--- a/packages/esql/src/ast/visitor/types.ts
+++ b/packages/esql/src/ast/visitor/types.ts
@@ -119,7 +119,8 @@ export type CommandVisitorInput<Methods extends VisitorMethods> = AnyToVoid<
     VisitorInput<Methods, 'visitDedupCommand'> &
     VisitorInput<Methods, 'visitUserAgentCommand'> &
     VisitorInput<Methods, 'visitIpLocationCommand'> &
-    VisitorInput<Methods, 'visitRegisteredDomainCommand'> // agent-marker: append new VisitorInput entries here
+    VisitorInput<Methods, 'visitRegisteredDomainCommand'> &
+    VisitorInput<Methods, 'visitHighlightCommand'> // agent-marker: append new VisitorInput entries here
 >;
 
 /**
@@ -157,7 +158,8 @@ export type CommandVisitorOutput<Methods extends VisitorMethods> =
   | VisitorOutput<Methods, 'visitDedupCommand'>
   | VisitorOutput<Methods, 'visitUserAgentCommand'>
   | VisitorOutput<Methods, 'visitIpLocationCommand'>
-  | VisitorOutput<Methods, 'visitRegisteredDomainCommand'>; // agent-marker: append new VisitorOutput entries here
+  | VisitorOutput<Methods, 'visitRegisteredDomainCommand'>
+  | VisitorOutput<Methods, 'visitHighlightCommand'>; // agent-marker: append new VisitorOutput entries here
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface VisitorMethods<
@@ -232,6 +234,11 @@ export interface VisitorMethods<
   >;
   visitIpLocationCommand?: Visitor<
     contexts.IpLocationCommandVisitorContext<Visitors, Data>,
+    any,
+    any
+  >;
+  visitHighlightCommand?: Visitor<
+    contexts.HighlightCommandVisitorContext<Visitors, Data>,
     any,
     any
   >;

--- a/packages/esql/src/parser/__tests__/highlight.test.ts
+++ b/packages/esql/src/parser/__tests__/highlight.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EsqlQuery } from '../../composer/query';
+import { Walker } from '../../ast/walker';
+import { BasicPrettyPrinter } from '../../pretty_print';
+import type { ESQLAstHighlightCommand, ESQLAstQueryExpression } from '../../types';
+
+describe('HIGHLIGHT', () => {
+  const getHighlight = (ast: ESQLAstQueryExpression): ESQLAstHighlightCommand =>
+    Walker.match(ast, {
+      type: 'command',
+      name: 'highlight',
+    }) as ESQLAstHighlightCommand;
+
+  it('parses basic syntax with a single field', () => {
+    const src = 'FROM logs | HIGHLIGHT "fox" ON content';
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const cmd = getHighlight(ast);
+
+    expect(errors).toHaveLength(0);
+    expect(cmd).toMatchObject({
+      type: 'command',
+      name: 'highlight',
+      incomplete: false,
+      queryText: { type: 'literal', valueUnquoted: 'fox' },
+      highlightFields: [{ type: 'column', name: 'content' }],
+    });
+  });
+
+  it('parses multiple highlight fields', () => {
+    const src = 'FROM logs | HIGHLIGHT "ring sauron" ON title, body, summary';
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const cmd = getHighlight(ast);
+
+    expect(errors).toHaveLength(0);
+    expect(cmd.highlightFields).toMatchObject([
+      { type: 'column', name: 'title' },
+      { type: 'column', name: 'body' },
+      { type: 'column', name: 'summary' },
+    ]);
+  });
+
+  it('parses WITH map with pre_tags and post_tags', () => {
+    const src =
+      'FROM logs | HIGHLIGHT "fox" ON content WITH { "pre_tags": "<b>", "post_tags": "</b>" }';
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const cmd = getHighlight(ast);
+
+    expect(errors).toHaveLength(0);
+    expect(cmd.namedParameters).toMatchObject({
+      type: 'map',
+      entries: [
+        {
+          type: 'map-entry',
+          key: { type: 'literal', valueUnquoted: 'pre_tags' },
+          value: { type: 'literal', valueUnquoted: '<b>' },
+        },
+        {
+          type: 'map-entry',
+          key: { type: 'literal', valueUnquoted: 'post_tags' },
+          value: { type: 'literal', valueUnquoted: '</b>' },
+        },
+      ],
+    });
+  });
+
+  it('parses WITH map with encoder option', () => {
+    const src = 'FROM logs | HIGHLIGHT "ring" ON content WITH { "encoder": "html" }';
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const cmd = getHighlight(ast);
+
+    expect(errors).toHaveLength(0);
+    expect(cmd.namedParameters).toMatchObject({
+      type: 'map',
+      entries: [
+        {
+          type: 'map-entry',
+          key: { type: 'literal', valueUnquoted: 'encoder' },
+          value: { type: 'literal', valueUnquoted: 'html' },
+        },
+      ],
+    });
+  });
+
+  it('parses WITH map with numeric options', () => {
+    const src =
+      'FROM logs | HIGHLIGHT "fox" ON content WITH { "number_of_fragments": 3, "fragment_size": 150, "no_match_size": 50 }';
+    const { ast, errors } = EsqlQuery.fromSrc(src);
+    const cmd = getHighlight(ast);
+
+    expect(errors).toHaveLength(0);
+    expect(cmd.namedParameters).toMatchObject({
+      type: 'map',
+      entries: [
+        { key: { valueUnquoted: 'number_of_fragments' }, value: { value: 3 } },
+        { key: { valueUnquoted: 'fragment_size' }, value: { value: 150 } },
+        { key: { valueUnquoted: 'no_match_size' }, value: { value: 50 } },
+      ],
+    });
+  });
+
+  it('marks incomplete when query text is missing', () => {
+    const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT');
+    const cmd = getHighlight(ast);
+
+    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+    expect(cmd.queryText).toBeUndefined();
+  });
+
+  it('marks incomplete when ON clause is missing', () => {
+    const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT "fox"');
+    const cmd = getHighlight(ast);
+
+    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+    expect(cmd.highlightFields).toBeUndefined();
+  });
+
+  it('marks incomplete when ON fields are missing', () => {
+    const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT "fox" ON');
+    const cmd = getHighlight(ast);
+
+    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+  });
+
+  it('marks incomplete when WITH has no map', () => {
+    const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT "fox" ON content WITH');
+    const cmd = getHighlight(ast);
+
+    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+  });
+
+  it('round-trips single-field syntax through the pretty-printer', () => {
+    const src = 'FROM logs | HIGHLIGHT "fox" ON content';
+    const { ast } = EsqlQuery.fromSrc(src);
+
+    expect(BasicPrettyPrinter.query(ast)).toBe(src);
+  });
+
+  it('round-trips multi-field syntax through the pretty-printer', () => {
+    const src = 'FROM logs | HIGHLIGHT "ring sauron" ON title, body';
+    const { ast } = EsqlQuery.fromSrc(src);
+
+    expect(BasicPrettyPrinter.query(ast)).toBe(src);
+  });
+});

--- a/packages/esql/src/parser/__tests__/highlight.test.ts
+++ b/packages/esql/src/parser/__tests__/highlight.test.ts
@@ -8,7 +8,11 @@
 import { EsqlQuery } from '../../composer/query';
 import { Walker } from '../../ast/walker';
 import { BasicPrettyPrinter } from '../../pretty_print';
-import type { ESQLAstHighlightCommand, ESQLAstQueryExpression } from '../../types';
+import type {
+  ESQLAstHighlightCommand,
+  ESQLAstQueryExpression,
+  ESQLSingleAstItem,
+} from '../../types';
 
 describe('HIGHLIGHT', () => {
   const getHighlight = (ast: ESQLAstQueryExpression): ESQLAstHighlightCommand =>
@@ -16,6 +20,8 @@ describe('HIGHLIGHT', () => {
       type: 'command',
       name: 'highlight',
     }) as ESQLAstHighlightCommand;
+
+  const getArgs = (cmd: ESQLAstHighlightCommand) => cmd.args as ESQLSingleAstItem[];
 
   it('parses basic syntax with a single field', () => {
     const src = 'FROM logs | HIGHLIGHT "fox" ON content';
@@ -30,6 +36,37 @@ describe('HIGHLIGHT', () => {
       queryText: { type: 'literal', valueUnquoted: 'fox' },
       highlightFields: [{ type: 'column', name: 'content' }],
     });
+  });
+
+  it('populates args with the query text, ON option, and WITH option', () => {
+    const src = 'FROM logs | HIGHLIGHT "fox" ON content WITH { "encoder": "html" }';
+    const { ast } = EsqlQuery.fromSrc(src);
+    const cmd = getHighlight(ast);
+
+    expect(getArgs(cmd)).toMatchObject([
+      { type: 'literal', valueUnquoted: 'fox' },
+      {
+        type: 'option',
+        name: 'on',
+        args: [{ type: 'column', name: 'content' }],
+      },
+      {
+        type: 'option',
+        name: 'with',
+        args: [
+          {
+            type: 'map',
+            entries: [
+              {
+                type: 'map-entry',
+                key: { type: 'literal', valueUnquoted: 'encoder' },
+                value: { type: 'literal', valueUnquoted: 'html' },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
   });
 
   it('parses multiple highlight fields', () => {
@@ -108,30 +145,59 @@ describe('HIGHLIGHT', () => {
     const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT');
     const cmd = getHighlight(ast);
 
-    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true, args: [] });
     expect(cmd.queryText).toBeUndefined();
+    expect(cmd.highlightFields).toBeUndefined();
+    expect(cmd.namedParameters).toBeUndefined();
   });
 
   it('marks incomplete when ON clause is missing', () => {
     const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT "fox"');
     const cmd = getHighlight(ast);
 
-    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+    expect(cmd).toMatchObject({
+      name: 'highlight',
+      incomplete: true,
+      queryText: { type: 'literal', valueUnquoted: 'fox' },
+    });
+    expect(getArgs(cmd)).toMatchObject([{ type: 'literal', valueUnquoted: 'fox' }]);
     expect(cmd.highlightFields).toBeUndefined();
+    expect(cmd.namedParameters).toBeUndefined();
   });
 
   it('marks incomplete when ON fields are missing', () => {
     const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT "fox" ON');
     const cmd = getHighlight(ast);
 
-    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+    expect(cmd).toMatchObject({
+      name: 'highlight',
+      incomplete: true,
+      queryText: { type: 'literal', valueUnquoted: 'fox' },
+      highlightFields: [],
+    });
+    expect(getArgs(cmd)).toMatchObject([
+      { type: 'literal', valueUnquoted: 'fox' },
+      { type: 'option', name: 'on', incomplete: true, args: [] },
+    ]);
+    expect(cmd.namedParameters).toBeUndefined();
   });
 
   it('marks incomplete when WITH has no map', () => {
     const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT "fox" ON content WITH');
     const cmd = getHighlight(ast);
 
-    expect(cmd).toMatchObject({ name: 'highlight', incomplete: true });
+    expect(cmd).toMatchObject({
+      name: 'highlight',
+      incomplete: true,
+      queryText: { type: 'literal', valueUnquoted: 'fox' },
+      highlightFields: [{ type: 'column', name: 'content' }],
+      namedParameters: { type: 'map', incomplete: true, entries: [] },
+    });
+    expect(getArgs(cmd)).toMatchObject([
+      { type: 'literal', valueUnquoted: 'fox' },
+      { type: 'option', name: 'on', incomplete: false },
+      { type: 'option', name: 'with', incomplete: true },
+    ]);
   });
 
   it('round-trips single-field syntax through the pretty-printer', () => {

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -2441,9 +2441,10 @@ export class CstToAstConverter {
         .map((qn) => this.fromQualifiedName(qn));
       const onOption = this.toOption('on', ctx._highlightFields, fields);
       onOption.location.min = onToken.symbol.start;
+      onOption.incomplete ||= fields.length === 0;
       command.args.push(onOption);
       command.highlightFields = fields;
-      command.incomplete ||= onOption.incomplete || fields.length === 0;
+      command.incomplete ||= onOption.incomplete;
     } else {
       command.incomplete = true;
     }

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -556,6 +556,12 @@ export class CstToAstConverter {
     if (dedupCommandCtx) {
       return this.fromDedupCommand(dedupCommandCtx);
     }
+
+    const highlightCommandCtx = ctx.highlightCommand();
+
+    if (highlightCommandCtx) {
+      return this.fromHighlightCommand(highlightCommandCtx);
+    }
     // agent-marker: append new command dispatcher branches here
     // throw new Error(`Unknown processing command: ${this.getSrc(ctx)}`;
   }
@@ -2413,6 +2419,46 @@ export class CstToAstConverter {
 
   private fromIpLocationCommand(ctx: cst.IpLocationCommandContext): ast.ESQLAstIpLocationCommand {
     return this.fromQualifiedNameAssignmentCommand('ip_location', ctx);
+  }
+
+  private fromHighlightCommand(ctx: cst.HighlightCommandContext): ast.ESQLAstHighlightCommand {
+    const command = this.createCommand<'highlight', ast.ESQLAstHighlightCommand>('highlight', ctx);
+
+    const queryTextCtx = ctx._queryText;
+    if (queryTextCtx && !queryTextCtx.exception) {
+      const queryText = this.toStringLiteral(queryTextCtx);
+      command.queryText = queryText;
+      command.args.push(queryText);
+    } else {
+      command.incomplete = true;
+    }
+
+    const onToken = ctx.ON();
+    if (onToken && ctx._highlightFields) {
+      const fields = ctx._highlightFields
+        .qualifiedName_list()
+        .filter((qn) => !qn.exception)
+        .map((qn) => this.fromQualifiedName(qn));
+      const onOption = this.toOption('on', ctx._highlightFields, fields);
+      onOption.location.min = onToken.symbol.start;
+      command.args.push(onOption);
+      command.highlightFields = fields;
+      command.incomplete ||= onOption.incomplete || fields.length === 0;
+    } else {
+      command.incomplete = true;
+    }
+
+    const namedParamsCtx = ctx.commandNamedParameters();
+    const withOption = this.fromOptionalNamedParametersWithOption(namedParamsCtx);
+    if (withOption) {
+      command.namedParameters = withOption.args[0] as ast.ESQLSingleAstItem;
+      command.args.push(withOption);
+      command.incomplete ||= withOption.incomplete;
+    } else if (namedParamsCtx?.WITH()) {
+      command.incomplete = true;
+    }
+
+    return command;
   }
 
   // -------------------------------------------------------------- expressions

--- a/packages/esql/src/types.ts
+++ b/packages/esql/src/types.ts
@@ -25,7 +25,8 @@ export type ESQLAstCommand =
   | ESQLAstMetricsInfoCommand
   | ESQLAstUserAgentCommand
   | ESQLAstIpLocationCommand
-  | ESQLAstRegisteredDomainCommand;
+  | ESQLAstRegisteredDomainCommand
+  | ESQLAstHighlightCommand;
 
 export type ESQLAstAllCommands = ESQLAstCommand | ESQLAstHeaderCommand;
 
@@ -187,6 +188,12 @@ export interface ESQLAstIpLocationCommand extends ESQLCommand<'ip_location'> {
 export interface ESQLAstRegisteredDomainCommand extends ESQLCommand<'registered_domain'> {
   targetField: ESQLColumn;
   expression?: ESQLAstExpression;
+}
+
+export interface ESQLAstHighlightCommand extends ESQLCommand<'highlight'> {
+  queryText?: ESQLStringLiteral;
+  highlightFields?: ESQLColumn[];
+  namedParameters?: ESQLSingleAstItem;
 }
 
 /**


### PR DESCRIPTION
partially addresses:  https://github.com/elastic/kibana/issues/274274

## Summary

Wires the new `HIGHLIGHT` command (added in grammar sync #151) into the AST layer.
The grammar rule is:

`HIGHLIGHT queryText=string ON highlightFields=qualifiedNames [WITH { ... }]`

## Details

Changes:

- `src/types.ts` — adds `ESQLAstHighlightCommand` interface (`queryText?`, `highlightFields`, `namedParameters?`) and extends the `ESQLAstCommand` union
- `src/ast/visitor/contexts.ts` — adds `HighlightCommandVisitorContext`
- `src/ast/visitor/types.ts` — extends `CommandVisitorInput`, `CommandVisitorOutput`, and `VisitorMethods` with `visitHighlightCommand`
- `src/ast/visitor/global_visitor_context.ts` — adds the '`highlight'` dispatcher case and public `visitHighlightCommand()` method
- `src/parser/core/cst_to_ast_converter.ts` — adds the dispatcher branch and `fromHighlightCommand()`, which converts the query-text string, ON fields (stored as an `on` option), and the optional `WITH` map
- `src/parser/__tests__/highlight.test.ts` — 8 tests covering: basic single-field parse, multi-field parse, all `WITH` map keys (`pre_tags`, `post_tags`, `encoder`, `number_of_fragments`, `fragment_size`, `no_match_size`), incomplete-input handling, and pretty-printer round-trips


<!-- BREAKING CHANGE: explain breaking changes added in this PR. -->

### Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Unit tests have been added or updated.
- [x] A changeset has been added (`yarn changeset`) if this change should be released. You choose the bump level (`patch` / `minor` / `major`) there — see [docs/RELEASE.md](../docs/RELEASE.md).
- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format (`feat`, `fix`, `refactor`, `perf`, `build`, `docs`, `chore`, `revert`) — this is enforced by CI and keeps the history and changelog clean. Note: the title no longer drives versioning; the changeset does.
