### PR TITLE
fix: publish packages with Yarn

### DIFF
--- a/.changeset/tangy-oranges-itch.md
+++ b/.changeset/tangy-oranges-itch.md
@@ -1,0 +1,6 @@
+---
+'@elastic/esql': patch
+'@elastic/pretty-printer': patch
+---
+
+Fix package publishing through Yarn workspaces.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -40,6 +40,8 @@ Review this PR, then merge it when you are ready to release.
 
 When the version PR is merged, the Changesets action runs again on `main`. This time there are no pending changesets, so instead of opening a PR it publishes every package to NPM `yarn changeset:publish`.
 
+The `changeset:publish` script delegates to `yarn workspaces foreach --all --no-private --topological npm publish --access public`.
+
 Each package declares `"publishConfig": { "provenance": true }` in its `package.json`. Changesets publishes via `yarn npm publish` under Yarn Berry, which reads that field and attaches [npm provenance](https://docs.npmjs.com/generating-provenance-statements) — linking the npm artifact to the specific GitHub Actions run that built it (verifiable via `npm audit signatures`). This requires `id-token: write` on the release job, which is already set.
 
 A GitHub Release is created automatically by the action for each published package.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:antlr4:promql": "yarn workspace @elastic/esql build:antlr4:promql",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "yarn workspaces foreach --all --no-private --topological npm publish --access public"
   },
   "devDependencies": {
     "@babel/core": "8.0.1",


### PR DESCRIPTION
## Summary

I tried to download the v4.7.0 in kibana and I received this error
```javascript 
error Couldn't find package "@elastic/pretty-printer@workspace:^" required by "@elastic/esql@4.7.0" on the "npm" registry.
```
I found this issue to be similar https://github.com/changesets/changesets/issues/1454  
so internally changeset use npm (probabily also pnpn) but not yarn and  you can't resolve the workspace

I change the way to publish the package using yarn.

Note about` --topology`
`@elastic/esq`l depends on `@elastic/pretty-printer`, so it publishes @elastic/pretty-printer first, then `@elastic/esql`.

I did a test with a local registry (Verdaccio)
