### PR TITLE
ci: do not error if a package is already published, simply ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:antlr4:promql": "yarn workspace @elastic/esql build:antlr4:promql",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:publish": "yarn workspaces foreach --all --no-private --topological npm publish --access public"
+    "changeset:publish": "yarn workspaces foreach --all --no-private --topological npm publish --access public --tolerate-republish"
   },
   "devDependencies": {
     "@babel/core": "8.0.1",


### PR DESCRIPTION
## Summary

- We are using a custom Yarn publish command, instead of the built-in Changesets publish command; this is needed to resolve `"workspace:*"` references before publication.
- However, it also means that now Yarn tries to publish on every merge to `main`, and fails if the package is already published. This change will make Yarn fail gracefully, and simply do nothing if the package is already published.