### PR TITLE
[ES|QL] New 'invalidUnquotedIdentifier' error for parser errors

### DIFF
--- a/.changeset/rename-unquoted-identifier-error.md
+++ b/.changeset/rename-unquoted-identifier-error.md
@@ -1,0 +1,5 @@
+---
+'@elastic/esql': patch
+---
+
+Parser errors caused by invalid characters in unquoted identifiers now produce a dedicated `invalidUnquotedIdentifier` error code instead of the generic `syntaxError`. The error span covers the full identifier rather than just the offending character, making it easier for consumers to extract and rewrite the identifier.

--- a/packages/esql/src/parser/__tests__/rename.test.ts
+++ b/packages/esql/src/parser/__tests__/rename.test.ts
@@ -54,4 +54,33 @@ describe('RENAME', () => {
       });
     });
   });
+
+  describe('incorrectly formatted', () => {
+    it('reports real, token-located syntaxErrors when the new (unquoted) name needs backticks', () => {
+      // The invalid identifier is the *new* name (right of AS).
+      const src = 'FROM logs-* | RENAME agent.id AS agent-id';
+      const { errors } = EsqlQuery.fromSrc(src);
+
+      expect(errors).toMatchObject([
+        { code: 'invalidUnquotedIdentifier', startColumn: 39, endColumn: 40 },
+        { code: 'syntaxError', startColumn: 40, endColumn: 42 },
+      ]);
+    });
+
+    it('collapses to a single, unlocated parseError when the old (unquoted) name needs backticks', () => {
+      // The invalid identifier is the *old* name (left of AS).
+      const src = 'FROM logs-* | RENAME agent-id AS agentId';
+      const { errors } = EsqlQuery.fromSrc(src);
+
+      expect(errors).toMatchObject([
+        {
+          code: 'parseError',
+          startLineNumber: 0,
+          startColumn: 0,
+          endLineNumber: 0,
+          endColumn: 0,
+        },
+      ]);
+    });
+  });
 });

--- a/packages/esql/src/parser/__tests__/rename.test.ts
+++ b/packages/esql/src/parser/__tests__/rename.test.ts
@@ -62,7 +62,12 @@ describe('RENAME', () => {
       const { errors } = EsqlQuery.fromSrc(src);
 
       expect(errors).toMatchObject([
-        { code: 'invalidUnquotedIdentifier', startColumn: 39, endColumn: 40 },
+        {
+          code: 'invalidUnquotedIdentifier',
+          message: "invalidUnquotedIdentifier: Field name contains invalid character '-'",
+          startColumn: 39,
+          endColumn: 40,
+        },
         { code: 'syntaxError', startColumn: 40, endColumn: 42 },
       ]);
     });

--- a/packages/esql/src/parser/__tests__/rename.test.ts
+++ b/packages/esql/src/parser/__tests__/rename.test.ts
@@ -65,10 +65,10 @@ describe('RENAME', () => {
         {
           code: 'invalidUnquotedIdentifier',
           message: "invalidUnquotedIdentifier: Field name contains invalid character '-'",
-          startColumn: 39,
-          endColumn: 40,
+          startColumn: 34,
+          endColumn: 42,
         },
-        { code: 'syntaxError', startColumn: 40, endColumn: 42 },
+        { code: 'syntaxError' },
       ]);
     });
 

--- a/packages/esql/src/parser/core/esql_error_listener.ts
+++ b/packages/esql/src/parser/core/esql_error_listener.ts
@@ -6,56 +6,18 @@
  */
 
 import * as antlr4 from 'antlr4';
-import { EsqlLexer } from '@elastic/esql-grammar';
 import { getPosition } from './tokens';
+import {
+  TOKEN_RECOGNITION_ERROR_PREFIX,
+  isUnquotedIdentifierError,
+  expandSpanToIdentifier,
+} from './helpers';
 import type { EditorError } from '../../types';
 
 // These will need to be manually updated whenever the relevant grammar changes.
 const SYNTAX_ERRORS_TO_IGNORE = [
   `mismatched input '<EOF>' expecting {'row', 'from', 'ts', 'set', 'show'}`,
 ];
-
-const TOKEN_RECOGNITION_ERROR_PREFIX = 'token recognition error at:';
-
-// Lexer modes in which an unquoted identifier/pattern is expected (e.g. RENAME's
-// old/new names). A "token recognition error" raised while in one of these modes
-// means the offending character can never form a valid unquoted identifier there
-// (unlike, say, WHERE, where the same character may be a valid operator) — i.e.
-// the identifier likely needs backticks.
-const UNQUOTED_IDENTIFIER_ERROR_MODES = new Set<number>([EsqlLexer.RENAME_MODE]);
-
-function isUnquotedIdentifierError(
-  recognizer: antlr4.Recognizer<unknown>,
-  offendingSymbol: unknown,
-  message: string
-): boolean {
-  return (
-    offendingSymbol == null &&
-    message.startsWith(TOKEN_RECOGNITION_ERROR_PREFIX) &&
-    recognizer instanceof antlr4.Lexer &&
-    UNQUOTED_IDENTIFIER_ERROR_MODES.has(recognizer.getMode())
-  );
-}
-
-const ID_CHARS_BEFORE = /[a-zA-Z0-9._@*]+$/;
-const ID_CHARS_AFTER = /^[^\s|,()[\]]+/;
-
-function expandSpanToIdentifier(
-  lexer: antlr4.Lexer,
-  column: number
-): { startColumn: number; endColumn: number } {
-  const input = (lexer as unknown as { inputStream: antlr4.CharStream }).inputStream;
-  const errorIdx = lexer._tokenStartCharIndex;
-  const src = input.getText(0, input.size - 1);
-
-  const beforeLen = ID_CHARS_BEFORE.exec(src.slice(0, errorIdx))?.[0].length ?? 0;
-  const afterLen = ID_CHARS_AFTER.exec(src.slice(errorIdx + 1))?.[0].length ?? 0;
-
-  return {
-    startColumn: column + 1 - beforeLen,
-    endColumn: column + 2 + afterLen,
-  };
-}
 
 const REPLACE_DEV = /,{0,1}(?<!\s)\s*DEV_\w+\s*/g;
 const REPLACE_ORPHAN_COMMA = /{, /g;

--- a/packages/esql/src/parser/core/esql_error_listener.ts
+++ b/packages/esql/src/parser/core/esql_error_listener.ts
@@ -63,15 +63,19 @@ export class ESQLErrorListener extends antlr4.ErrorListener<unknown> {
       return;
     }
 
-    const textMessage = `SyntaxError: ${message}`;
-
     const tokenPosition = getPosition(offendingSymbol as antlr4.Token);
     const startColumn = offendingSymbol && tokenPosition ? tokenPosition.min + 1 : column + 1;
     const endColumn = offendingSymbol && tokenPosition ? tokenPosition.max + 1 : column + 2;
 
-    const code = isUnquotedIdentifierError(recognizer, offendingSymbol, message)
-      ? 'invalidUnquotedIdentifier'
-      : 'syntaxError';
+    const unquotedIdentifierError = isUnquotedIdentifierError(recognizer, offendingSymbol, message);
+    const invalidChar = unquotedIdentifierError
+      ? message.replace(TOKEN_RECOGNITION_ERROR_PREFIX, '').trim()
+      : undefined;
+
+    const code = unquotedIdentifierError ? 'invalidUnquotedIdentifier' : 'syntaxError';
+    const textMessage = unquotedIdentifierError
+      ? `invalidUnquotedIdentifier: Field name contains invalid character ${invalidChar}`
+      : `SyntaxError: ${message}`;
 
     this.errors.push({
       startLineNumber: line,

--- a/packages/esql/src/parser/core/esql_error_listener.ts
+++ b/packages/esql/src/parser/core/esql_error_listener.ts
@@ -37,6 +37,26 @@ function isUnquotedIdentifierError(
   );
 }
 
+const ID_CHARS_BEFORE = /[a-zA-Z0-9._@*]+$/;
+const ID_CHARS_AFTER = /^[^\s|,()[\]]+/;
+
+function expandSpanToIdentifier(
+  lexer: antlr4.Lexer,
+  column: number
+): { startColumn: number; endColumn: number } {
+  const input = (lexer as unknown as { inputStream: antlr4.CharStream }).inputStream;
+  const errorIdx = lexer._tokenStartCharIndex;
+  const src = input.getText(0, input.size - 1);
+
+  const beforeLen = ID_CHARS_BEFORE.exec(src.slice(0, errorIdx))?.[0].length ?? 0;
+  const afterLen = ID_CHARS_AFTER.exec(src.slice(errorIdx + 1))?.[0].length ?? 0;
+
+  return {
+    startColumn: column + 1 - beforeLen,
+    endColumn: column + 2 + afterLen,
+  };
+}
+
 const REPLACE_DEV = /,{0,1}(?<!\s)\s*DEV_\w+\s*/g;
 const REPLACE_ORPHAN_COMMA = /{, /g;
 
@@ -64,10 +84,13 @@ export class ESQLErrorListener extends antlr4.ErrorListener<unknown> {
     }
 
     const tokenPosition = getPosition(offendingSymbol as antlr4.Token);
-    const startColumn = offendingSymbol && tokenPosition ? tokenPosition.min + 1 : column + 1;
-    const endColumn = offendingSymbol && tokenPosition ? tokenPosition.max + 1 : column + 2;
+    let startColumn = offendingSymbol && tokenPosition ? tokenPosition.min + 1 : column + 1;
+    let endColumn = offendingSymbol && tokenPosition ? tokenPosition.max + 1 : column + 2;
 
     const unquotedIdentifierError = isUnquotedIdentifierError(recognizer, offendingSymbol, message);
+    if (unquotedIdentifierError) {
+      ({ startColumn, endColumn } = expandSpanToIdentifier(recognizer as antlr4.Lexer, column));
+    }
     const invalidChar = unquotedIdentifierError
       ? message.replace(TOKEN_RECOGNITION_ERROR_PREFIX, '').trim()
       : undefined;

--- a/packages/esql/src/parser/core/esql_error_listener.ts
+++ b/packages/esql/src/parser/core/esql_error_listener.ts
@@ -6,6 +6,7 @@
  */
 
 import * as antlr4 from 'antlr4';
+import { EsqlLexer } from '@elastic/esql-grammar';
 import { getPosition } from './tokens';
 import type { EditorError } from '../../types';
 
@@ -13,6 +14,28 @@ import type { EditorError } from '../../types';
 const SYNTAX_ERRORS_TO_IGNORE = [
   `mismatched input '<EOF>' expecting {'row', 'from', 'ts', 'set', 'show'}`,
 ];
+
+const TOKEN_RECOGNITION_ERROR_PREFIX = 'token recognition error at:';
+
+// Lexer modes in which an unquoted identifier/pattern is expected (e.g. RENAME's
+// old/new names). A "token recognition error" raised while in one of these modes
+// means the offending character can never form a valid unquoted identifier there
+// (unlike, say, WHERE, where the same character may be a valid operator) — i.e.
+// the identifier likely needs backticks.
+const UNQUOTED_IDENTIFIER_ERROR_MODES = new Set<number>([EsqlLexer.RENAME_MODE]);
+
+function isUnquotedIdentifierError(
+  recognizer: antlr4.Recognizer<unknown>,
+  offendingSymbol: unknown,
+  message: string
+): boolean {
+  return (
+    offendingSymbol == null &&
+    message.startsWith(TOKEN_RECOGNITION_ERROR_PREFIX) &&
+    recognizer instanceof antlr4.Lexer &&
+    UNQUOTED_IDENTIFIER_ERROR_MODES.has(recognizer.getMode())
+  );
+}
 
 const REPLACE_DEV = /,{0,1}(?<!\s)\s*DEV_\w+\s*/g;
 const REPLACE_ORPHAN_COMMA = /{, /g;
@@ -46,6 +69,10 @@ export class ESQLErrorListener extends antlr4.ErrorListener<unknown> {
     const startColumn = offendingSymbol && tokenPosition ? tokenPosition.min + 1 : column + 1;
     const endColumn = offendingSymbol && tokenPosition ? tokenPosition.max + 1 : column + 2;
 
+    const code = isUnquotedIdentifierError(recognizer, offendingSymbol, message)
+      ? 'invalidUnquotedIdentifier'
+      : 'syntaxError';
+
     this.errors.push({
       startLineNumber: line,
       endLineNumber: line,
@@ -53,7 +80,7 @@ export class ESQLErrorListener extends antlr4.ErrorListener<unknown> {
       endColumn,
       message: textMessage,
       severity: 'error',
-      code: 'syntaxError',
+      code,
     });
   }
 

--- a/packages/esql/src/parser/core/helpers.ts
+++ b/packages/esql/src/parser/core/helpers.ts
@@ -5,6 +5,48 @@
  * 2.0.
  */
 
+import * as antlr4 from 'antlr4';
+import { EsqlLexer } from '@elastic/esql-grammar';
+
+export const TOKEN_RECOGNITION_ERROR_PREFIX = 'token recognition error at:';
+
+// Lexer modes where identifier patterns are expected and operators like `-` are not valid tokens.
+// A token-recognition error in these modes means the identifier needs quoting, not a structural fix.
+export const UNQUOTED_IDENTIFIER_ERROR_MODES = new Set<number>([EsqlLexer.RENAME_MODE]);
+
+export function isUnquotedIdentifierError(
+  recognizer: antlr4.Recognizer<unknown>,
+  offendingSymbol: unknown,
+  message: string
+): boolean {
+  return (
+    offendingSymbol == null &&
+    message.startsWith(TOKEN_RECOGNITION_ERROR_PREFIX) &&
+    recognizer instanceof antlr4.Lexer &&
+    UNQUOTED_IDENTIFIER_ERROR_MODES.has(recognizer.getMode())
+  );
+}
+
+const ID_CHARS_BEFORE = /[a-zA-Z0-9._@*]+$/;
+const ID_CHARS_AFTER = /^[^\s|,()[\]]+/;
+
+export function expandSpanToIdentifier(
+  lexer: antlr4.Lexer,
+  column: number
+): { startColumn: number; endColumn: number } {
+  const input = (lexer as unknown as { inputStream: antlr4.CharStream }).inputStream;
+  const errorIdx = lexer._tokenStartCharIndex;
+  const src = input.getText(0, input.size - 1);
+
+  const beforeLen = ID_CHARS_BEFORE.exec(src.slice(0, errorIdx))?.[0].length ?? 0;
+  const afterLen = ID_CHARS_AFTER.exec(src.slice(errorIdx + 1))?.[0].length ?? 0;
+
+  return {
+    startColumn: column + 1 - beforeLen,
+    endColumn: column + 2 + afterLen,
+  };
+}
+
 export const nonNullable = <T>(v: T): v is NonNullable<T> => {
   return v != null;
 };


### PR DESCRIPTION
part of https://github.com/elastic/kibana/issues/209116
dependent by https://github.com/elastic/kibana/pull/278337

## Summary

### Problem
When a field name containing characters that require backtick-quoting is used unquoted in a command that expects an identifier pattern, the parser emits a generic `syntaxError` anchored to only the single offending character. Because `syntaxError` is shared across every syntax problem in the grammar, consumers have no reliable way to distinguish "this identifier needs backticks" from an unrelated typo or structural error. The narrow single-character span also makes it impossible to know what text would need to be rewritten.

### Fix
The error listener now checks whether a token-recognition error was raised while the lexer was in an identifier-pattern mode. When it was, the error is emitted with code `invalidUnquotedIdentifier` instead of `syntaxError`, and its span is expanded to cover the full intended identifier by scanning outward from the bad character. All other errors continue to produce `syntaxError` unchanged.

### Result
Consumers can key on `invalidUnquotedIdentifier` to handle this case specifically, and can retrieve the full identifier directly from the source using the error's `startColumn`/`endColumn` — no message parsing, no additional scanning required.

### Checklist

- [x] Unit tests have been added or updated.
- [ ] The proper documentation has been added or updated.
- [x] A changeset has been added (`yarn changeset`) if this change should be released. See [docs/RELEASE.md](../docs/RELEASE.md).
- [ ] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax and selected a `major` bump in the changeset.
- [x] The PR is opened as a draft until CI is green.
