### PR TITLE
Fix for pretty-printer for empty query

### DIFF
--- a/.changeset/fix-empty-query-wrapping-printer.md
+++ b/.changeset/fix-empty-query-wrapping-printer.md
@@ -1,0 +1,5 @@
+---
+"@elastic/esql": patch
+---
+
+Fix crash in `WrappingPrettyPrinter` when printing an empty query

--- a/packages/esql/src/pretty_print/wrapping_pretty_printer/__tests__/printer.test.ts
+++ b/packages/esql/src/pretty_print/wrapping_pretty_printer/__tests__/printer.test.ts
@@ -18,6 +18,10 @@ const reprint = (src: string, opts?: WrappingPrettyPrinterOptions) => {
 
 describe('WrappingPrettyPrinter (Doc IR)', () => {
   describe('basic queries', () => {
+    test('empty query', () => {
+      expect(reprint('')).toBe('');
+    });
+
     test('single command', () => {
       expect(reprint('FROM index')).toBe('FROM index');
     });

--- a/packages/esql/src/pretty_print/wrapping_pretty_printer/printer.ts
+++ b/packages/esql/src/pretty_print/wrapping_pretty_printer/printer.ts
@@ -181,6 +181,9 @@ export class WrappingPrettyPrinter {
 
   protected docQuery(query: ESQLAstQueryExpression): Doc {
     const cmds = query.commands;
+
+    if (!cmds.length) return '';
+
     const hasHeader = !this.opts.skipHeader && !!query.header?.length;
     const forceMultiline =
       this.opts.multiline || getPrettyPrintStats(query).hasLineBreakingDecorations;


### PR DESCRIPTION
## Summary

Fix a crash in WrappingPrettyPrinter when printing an empty query string.

## Details

`docQuery` unconditionally accessed `cmds[0]` to extract top-comment decorations, which blew up with `TypeError: Cannot read properties of undefined` when the command list was empty. Added an early `return ''` guard immediately after reading `query.commands`, consistent with the same pattern used in `extractTopCommentDocs` and `buildCmdDoc`.

### Checklist

- [x] Unit tests have been added or updated.
- [x] A changeset has been added (`yarn changeset`) if this change should be released. See [docs/RELEASE.md](../docs/RELEASE.md).
- [x] The PR is opened as a draft until CI is green.
