### PR TITLE
Release notes on package publishing

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,9 @@
+# Configures the notes GitHub generates for each release, which the Release
+# workflow requests via `gh release create --generate-notes`.
+changelog:
+  exclude:
+    authors:
+      # The "chore: version packages" PRs.
+      - github-actions
+      # Dependency bumps.
+      - elastic-renovate-prod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,35 @@ jobs:
       - run: yarn build
 
       - name: Create Release Pull Request or Publish
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: yarn changeset:version
           publish: yarn changeset:publish
           commit: 'chore: version packages'
           title: 'chore: version packages'
+          # All packages share one version (Changesets `fixed` group), so the
+          # built-in per-package releases would mean one release and one tag per
+          # package. The next step creates a single `v<version>` release instead.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Yarn v4 reads YARN_NPM_AUTH_TOKEN as the npm registry auth token
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(node -p "require('./packages/esql/package.json').version")
+
+          if gh release view "v$version" >/dev/null 2>&1; then
+            echo "Release v$version already exists — skipping."
+            exit 0
+          fi
+
+          flags=(--title "v$version" --target "$GITHUB_SHA" --generate-notes)
+          if [[ "$version" == *-* ]]; then flags+=(--prerelease); fi
+
+          gh release create "v$version" "${flags[@]}"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -40,11 +40,13 @@ Review this PR, then merge it when you are ready to release.
 
 When the version PR is merged, the Changesets action runs again on `main`. This time there are no pending changesets, so instead of opening a PR it publishes every package to NPM `yarn changeset:publish`.
 
-The `changeset:publish` script delegates to `yarn workspaces foreach --all --no-private --topological npm publish --access public`.
+The `changeset:publish` script delegates to `yarn workspaces foreach --all --no-private --topological npm publish --access public --tolerate-republish`, then runs `yarn changeset tag`. The Changesets action decides whether a publish happened by scanning the publish command's stdout for `New tag: <pkg>@<version>` lines — `yarn npm publish` does not print them, so without it the action reports `published: false` and silently skips tagging and releases.
 
 Each package declares `"publishConfig": { "provenance": true }` in its `package.json`. Changesets publishes via `yarn npm publish` under Yarn Berry, which reads that field and attaches [npm provenance](https://docs.npmjs.com/generating-provenance-statements) — linking the npm artifact to the specific GitHub Actions run that built it (verifiable via `npm audit signatures`). This requires `id-token: write` on the release job, which is already set.
 
-A GitHub Release is created automatically by the action for each published package.
+### 4. The GitHub Release
+
+The action's built-in releases are per package, so with every package sharing one version they would produce 11 releases and 11 tags per release — and no `v<version>` tag at all. `createGithubReleases` is therefore set to `false`, and the workflow's final step creates a single release with `gh release create --generate-notes`:
 
 ---
 
@@ -94,4 +96,11 @@ To check what would be published without actually publishing:
 ```bash
 yarn changeset status              # lists pending changesets and projected version bump
 yarn changeset publish --dry-run   # shows what npm publish commands would run
+```
+
+To preview the GitHub Release notes without creating anything:
+
+```bash
+gh api repos/elastic/esql-js/releases/generate-notes \
+  -f tag_name=v4.18.0 -f previous_tag_name=v4.17.0 --jq .body
 ```

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sync:grammars": "./.buildkite/scripts/grammar_sync_local.sh",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:publish": "yarn workspaces foreach --all --no-private --topological npm publish --access public --tolerate-republish"
+    "changeset:publish": "yarn workspaces foreach --all --no-private --topological npm publish --access public --tolerate-republish && yarn changeset tag"
   },
   "devDependencies": {
     "@babel/core": "8.0.1",


### PR DESCRIPTION
## Summary

When we switched from NPM (Changesets) publishing to our custom Yarn script, we broke automatic GitHub release note generation. This should re-enable GitHub release note automatic generation once per release.