### PR TITLE
Fix parser escaped sequence parsing

### DIFF
--- a/.changeset/cool-turtles-post.md
+++ b/.changeset/cool-turtles-post.md
@@ -1,0 +1,5 @@
+---
+'@elastic/esql': patch
+---
+
+Correctly parse escaped sequences

--- a/packages/esql/src/parser/__tests__/literal.test.ts
+++ b/packages/esql/src/parser/__tests__/literal.test.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { parse } from '..';
-import type { ESQLLiteral } from '../../types';
+import { parse, Parser } from '..';
+import { BasicPrettyPrinter } from '../../pretty_print';
+import type { ESQLLiteral, ESQLStringLiteral } from '../../types';
 
 describe('literal expression', () => {
   it('NULL', () => {
@@ -148,6 +149,132 @@ describe('literal expression', () => {
             },
             {},
           ],
+        });
+      });
+
+      // Regression tests for https://github.com/elastic/esql-js/issues/212.
+      describe('escaped backslash before escape-letter (issue #212)', () => {
+        it(String.raw`\\r — backslash + r, not carriage-return`, () => {
+          const { root } = parse(String.raw`ROW "handlers\\run.cs"`);
+          const literal = root.commands[0].args[0] as ESQLStringLiteral;
+
+          expect(literal.valueUnquoted).toBe('handlers\\run.cs');
+          expect(literal.valueUnquoted.charCodeAt(8)).toBe(92);
+          expect(literal.valueUnquoted[8]).toBe('\\');
+          expect(literal.valueUnquoted[9]).toBe('r');
+        });
+
+        it(String.raw`\\n — backslash + n, not newline`, () => {
+          const { root } = parse(String.raw`ROW "a\\new.cs"`);
+          const literal = root.commands[0].args[0] as ESQLStringLiteral;
+
+          expect(literal.valueUnquoted).toBe('a\\new.cs');
+          expect(literal.valueUnquoted.charCodeAt(1)).toBe(92); // backslash
+          expect(literal.valueUnquoted.charCodeAt(2)).toBe(110); // 'n'
+        });
+
+        it(String.raw`\\t — backslash + t, not tab`, () => {
+          const { root } = Parser.parse(String.raw`ROW "a\\temp"`);
+          const literal = root.commands[0].args[0] as ESQLStringLiteral;
+
+          expect(literal.valueUnquoted).toBe('a\\temp');
+          expect(literal.valueUnquoted.charCodeAt(1)).toBe(92); // backslash
+          expect(literal.valueUnquoted.charCodeAt(2)).toBe(116); // 't'
+        });
+
+        it(String.raw`actual \r escape is still carriage-return`, () => {
+          const { root } = Parser.parse(String.raw`ROW "a\rb"`);
+
+          expect((root.commands[0].args[0] as ESQLStringLiteral).valueUnquoted).toBe('a\rb');
+        });
+
+        it(String.raw`actual \n escape is still newline`, () => {
+          const { root } = Parser.parse(String.raw`ROW "a\nb"`);
+
+          expect((root.commands[0].args[0] as ESQLStringLiteral).valueUnquoted).toBe('a\nb');
+        });
+
+        it(String.raw`actual \t escape is still tab`, () => {
+          const { root } = Parser.parse(String.raw`ROW "a\tb"`);
+
+          expect((root.commands[0].args[0] as ESQLStringLiteral).valueUnquoted).toBe('a\tb');
+        });
+
+        it('backslash before any other letter is unaffected', () => {
+          const { root } = Parser.parse(String.raw`ROW "a\\slash"`);
+
+          expect((root.commands[0].args[0] as ESQLStringLiteral).valueUnquoted).toBe('a\\slash');
+        });
+
+        it(String.raw`two consecutive escaped backslashes before n (\\\\n)`, () => {
+          const { root } = Parser.parse(String.raw`ROW "\\\\n"`);
+
+          expect((root.commands[0].args[0] as ESQLStringLiteral).valueUnquoted).toBe('\\\\n');
+        });
+
+        it('escaped backslash at end of string', () => {
+          const { root } = parse(String.raw`ROW "path\\"`);
+
+          expect((root.commands[0].args[0] as ESQLStringLiteral).valueUnquoted).toBe('path\\');
+        });
+      });
+
+      describe('round-trip: parse to BasicPrettyPrinter.print', () => {
+        const reprint = (src: string) => BasicPrettyPrinter.print(parse(src).root);
+
+        it(String.raw`handlers\\run.cs (issue #212 exact repro)`, () => {
+          const src = String.raw`FROM a | WHERE x == "handlers\\run.cs"`;
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        // it('a\\\\new.cs (backslash + n)', () => {
+        it(String.raw`a\\new.cs (backslash + n)`, () => {
+          const src = String.raw`FROM a | WHERE x == "a\\new.cs"`;
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        it(String.raw`a\\temp (backslash + t)`, () => {
+          const src = String.raw`FROM a | WHERE x == "a\\temp"`;
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        it(String.raw`actual newline escape \n`, () => {
+          const src = 'FROM a | WHERE x == "a\\nb"';
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        it(String.raw`actual tab escape \t`, () => {
+          const src = 'FROM a | WHERE x == "a\\tb"';
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        it(String.raw`actual carriage-return escape \r`, () => {
+          const src = String.raw`FROM a | WHERE x == "a\rb"`;
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        it('escaped double-quote', () => {
+          const src = String.raw`FROM a | WHERE x == "say \"hi\""`;
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        it('two consecutive escaped backslashes', () => {
+          const src = String.raw`FROM a | WHERE x == "a\\\\b"`;
+
+          expect(reprint(src)).toBe(src);
+        });
+
+        it('escaped backslash before non-special letter is unaffected', () => {
+          const src = String.raw`FROM a | WHERE x == "a\\slash"`;
+
+          expect(reprint(src)).toBe(src);
         });
       });
     });

--- a/packages/esql/src/parser/__tests__/literal.test.ts
+++ b/packages/esql/src/parser/__tests__/literal.test.ts
@@ -228,7 +228,6 @@ describe('literal expression', () => {
           expect(reprint(src)).toBe(src);
         });
 
-        // it('a\\\\new.cs (backslash + n)', () => {
         it(String.raw`a\\new.cs (backslash + n)`, () => {
           const src = String.raw`FROM a | WHERE x == "a\\new.cs"`;
 

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -3706,12 +3706,20 @@ export class CstToAstConverter {
     let valueUnquoted = isTripleQuoted ? quotedString.slice(3, -3) : quotedString.slice(1, -1);
 
     if (!isTripleQuoted) {
-      valueUnquoted = valueUnquoted
-        .replace(/\\"/g, '"')
-        .replace(/\\r/g, '\r')
-        .replace(/\\n/g, '\n')
-        .replace(/\\t/g, '\t')
-        .replace(/\\\\/g, '\\');
+      valueUnquoted = valueUnquoted.replace(/\\([tnr"\\])/g, (_, c: string) => {
+        switch (c) {
+          case 't':
+            return '\t';
+          case 'n':
+            return '\n';
+          case 'r':
+            return '\r';
+          case '"':
+            return '"';
+          default:
+            return '\\';
+        }
+      });
     }
 
     return Builder.expression.literal.string(

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -3716,8 +3716,10 @@ export class CstToAstConverter {
             return '\r';
           case '"':
             return '"';
-          default:
+          case '\\':
             return '\\';
+          default:
+            return c;
         }
       });
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/esql-js/issues/212.

### Checklist

- [x] Unit tests have been added or updated.
- [x] A changeset has been added (`yarn changeset`) if this change should be released. See [docs/RELEASE.md](../docs/RELEASE.md).
- [x] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax and selected a `major` bump in the changeset.
- [x] The PR is opened as a draft until CI is green.
