### PR TITLE
[ES|QL] Highlight command: prefix arg

### DIFF
--- a/.changeset/highlight-prefix-support.md
+++ b/.changeset/highlight-prefix-support.md
@@ -1,0 +1,6 @@
+---
+'@elastic/esql': patch
+'@elastic/esql-types': patch
+---
+
+Add prefix support to HIGHLIGHT command AST: parse the optional `prefix = "..."` clause into `ESQLAstHighlightCommand.prefix` and expose the binary-expression assignment in `args`.

--- a/packages/esql-types/src/types.ts
+++ b/packages/esql-types/src/types.ts
@@ -198,6 +198,7 @@ export interface ESQLAstRegisteredDomainCommand extends ESQLCommand<'registered_
 }
 
 export interface ESQLAstHighlightCommand extends ESQLCommand<'highlight'> {
+  prefix?: ESQLStringLiteral;
   queryExpression?: ESQLAstExpression;
   highlightFields?: ESQLColumn[];
   namedParameters?: ESQLSingleAstItem;

--- a/packages/esql/src/parser/__tests__/highlight.test.ts
+++ b/packages/esql/src/parser/__tests__/highlight.test.ts
@@ -213,4 +213,93 @@ describe('HIGHLIGHT', () => {
 
     expect(BasicPrettyPrinter.query(ast)).toBe(src);
   });
+
+  describe('prefix clause', () => {
+    it('leaves prefix undefined when no prefix clause is present', () => {
+      const src = 'FROM logs | HIGHLIGHT "fox" ON content';
+      const { ast } = EsqlQuery.fromSrc(src);
+      const cmd = getHighlight(ast);
+
+      expect(cmd.prefix).toBeUndefined();
+    });
+
+    it('parses prefix = "hl_"', () => {
+      const src = 'FROM logs | HIGHLIGHT prefix = "hl_" "fox" ON content';
+      const { ast, errors } = EsqlQuery.fromSrc(src);
+      const cmd = getHighlight(ast);
+
+      expect(errors).toHaveLength(0);
+      expect(cmd.prefix).toMatchObject({ type: 'literal', valueUnquoted: 'hl_' });
+    });
+
+    it('parses empty prefix (prefix = "")', () => {
+      const src = 'FROM logs | HIGHLIGHT prefix = "" "fox" ON content';
+      const { ast, errors } = EsqlQuery.fromSrc(src);
+      const cmd = getHighlight(ast);
+
+      expect(errors).toHaveLength(0);
+      expect(cmd.prefix).toMatchObject({ type: 'literal', valueUnquoted: '' });
+    });
+
+    it('parses whitespace prefix (prefix = "hl ")', () => {
+      const src = 'FROM logs | HIGHLIGHT prefix = "hl " "fox" ON content';
+      const { ast, errors } = EsqlQuery.fromSrc(src);
+      const cmd = getHighlight(ast);
+
+      expect(errors).toHaveLength(0);
+      expect(cmd.prefix).toMatchObject({ type: 'literal', valueUnquoted: 'hl ' });
+    });
+
+    it('records prefix even when the keyword is not "prefix" (semantic check left to consumers)', () => {
+      const src = 'FROM logs | HIGHLIGHT foo = "hl_" "fox" ON content';
+      const { ast } = EsqlQuery.fromSrc(src);
+      const cmd = getHighlight(ast);
+
+      // The JS parser is lenient — it records whatever identifier appeared.
+      // ES|QL servers will reject non-"prefix" keywords; consumers must validate.
+      expect(cmd.prefix).toMatchObject({ type: 'literal', valueUnquoted: 'hl_' });
+    });
+
+    it('puts the prefix assignment as args[0], before the query expression', () => {
+      const src = 'FROM logs | HIGHLIGHT prefix = "hl_" "fox" ON content';
+      const { ast } = EsqlQuery.fromSrc(src);
+      const cmd = getHighlight(ast);
+
+      expect(getArgs(cmd)).toMatchObject([
+        {
+          type: 'function',
+          subtype: 'binary-expression',
+          name: '=',
+          args: [
+            { type: 'column', name: 'prefix' },
+            { type: 'literal', valueUnquoted: 'hl_' },
+          ],
+        },
+        { type: 'literal', valueUnquoted: 'fox' },
+        { type: 'option', name: 'on', args: [{ type: 'column', name: 'content' }] },
+      ]);
+    });
+
+    it('marks incomplete when ASSIGN is present but prefix string is missing', () => {
+      const { ast } = EsqlQuery.fromSrc('FROM index | HIGHLIGHT prefix =');
+      const cmd = getHighlight(ast);
+
+      expect(cmd.incomplete).toBe(true);
+      expect(cmd.prefix).toBeUndefined();
+    });
+
+    it('round-trips prefix = "hl_" through the pretty-printer', () => {
+      const src = 'FROM logs | HIGHLIGHT prefix = "hl_" "fox" ON content';
+      const { ast } = EsqlQuery.fromSrc(src);
+
+      expect(BasicPrettyPrinter.query(ast)).toBe(src);
+    });
+
+    it('round-trips empty prefix through the pretty-printer', () => {
+      const src = 'FROM logs | HIGHLIGHT prefix = "" "fox" ON content';
+      const { ast } = EsqlQuery.fromSrc(src);
+
+      expect(BasicPrettyPrinter.query(ast)).toBe(src);
+    });
+  });
 });

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -2426,6 +2426,25 @@ export class CstToAstConverter {
   private fromHighlightCommand(ctx: cst.HighlightCommandContext): ast.ESQLAstHighlightCommand {
     const command = this.createCommand<'highlight', ast.ESQLAstHighlightCommand>('highlight', ctx);
 
+    if (ctx.ASSIGN()) {
+      if (ctx._prefix && !ctx._prefix.exception) {
+        const prefixLiteral = this.toStringLiteral(ctx._prefix);
+        const keyword = this.toColumn(ctx._prefixKeyword);
+        const assignment = this.toFunction(
+          ctx.ASSIGN().getText(),
+          ctx,
+          undefined,
+          'binary-expression'
+        ) as ast.ESQLBinaryExpression;
+        assignment.args.push(keyword, prefixLiteral);
+        assignment.location = this.extendLocationToArgs(assignment);
+        command.prefix = prefixLiteral;
+        command.args.push(assignment);
+      } else {
+        command.incomplete = true;
+      }
+    }
+
     const queryExprCtx = ctx._queryExpression;
     if (queryExprCtx && !queryExprCtx.exception) {
       const queryExpr = this.fromBooleanExpression(queryExprCtx);

--- a/packages/esql/src/pretty_print/constants.ts
+++ b/packages/esql/src/pretty_print/constants.ts
@@ -23,7 +23,13 @@
  * GROK input "pattern1", "pattern2", "pattern3"
  * ```
  */
-export const commandsWithNoCommaArgSeparator = new Set(['dissect', 'sample', 'fork', 'promql']);
+export const commandsWithNoCommaArgSeparator = new Set([
+  'dissect',
+  'sample',
+  'fork',
+  'promql',
+  'highlight',
+]);
 
 export const commandsWithSpecialCommaRules = new Map<string, (argIndex: number) => boolean>([
   ['grok', (argIndex: number) => argIndex > 1], // Comma before patterns starting from index 2


### PR DESCRIPTION
part of https://github.com/elastic/kibana/issues/274274

## Summary

The `HIGHLIGHT` command accepts an optional `prefix = "..."` clause that controls how output columns are named (e.g. `HIGHLIGHT prefix = "hl_" "fox" ON content` produces `hl_content` instead of `highlight_content`). The grammar already parsed it, but the CST→AST converter was dropping it, so downstream consumers had no way to distinguish the two forms.

**Changes**:

- `ESQLAstHighlightCommand` gains an optional `prefix?: ESQLStringLiteral` field. `undefined` means no prefix clause was present; `""` means an explicit empty prefix was written — the distinction matters because an empty prefix overwrites the source column.
- `fromHighlightCommand` now parses the prefix clause before the query expression, following the RERANK precedent: it emits a `binary-expression` (`prefix = "hl_"`) as `args[0]` alongside setting `command.prefix`, and marks `command.incomplete = true` when `ASSIGN` is present but the string is missing (mid-typing).
- `commandsWithNoCommaArgSeparator` gains `'highlight'` so the prefix assignment and query expression are space-separated in pretty-printed output, matching the source grammar.
- **Tests** cover: no prefix, `"hl_"`, empty `""`, whitespace `"hl "`, wrong keyword (recorded leniently — semantic validation is the server's job), `args` order, incomplete form, and two round-trip assertions.
- 
## Details

Technical details, breaking changes or considerations you have made while working in this PR.

### Checklist

- [x] Unit tests have been added or updated.
- [ ] The proper documentation has been added or updated.
- [x] A changeset has been added (`yarn changeset`) if this change should be released. See [docs/RELEASE.md](../docs/RELEASE.md).
- [ ] If this PR contains breaking changes, you have explained them using the `BREAKING CHANGE: change` syntax and selected a `major` bump in the changeset.
- [x] The PR is opened as a draft until CI is green.
