### PR TITLE
[ES|QL] fixes packages dependencies

### DIFF
--- a/.changeset/fix-esql-definitions-dep.md
+++ b/.changeset/fix-esql-definitions-dep.md
@@ -1,0 +1,5 @@
+---
+'@elastic/esql': patch
+---
+
+Fix broken type re-export of `DATE_PERIOD_UNITS`, `TIME_DURATION_UNITS`, and `TIME_SPAN_UNITS`: add `@elastic/esql-definitions` as an explicit dependency so the `./time` subpath resolves to the correct version in consumers that have an older version hoisted.

--- a/packages/esql/package.json
+++ b/packages/esql/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@elastic/esql-ast": "workspace:^",
+    "@elastic/esql-definitions": "workspace:^",
     "@elastic/esql-grammar": "workspace:^",
     "@elastic/esql-promql-grammar": "workspace:^",
     "@elastic/esql-traversal": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,6 +1015,7 @@ __metadata:
   resolution: "@elastic/esql@workspace:packages/esql"
   dependencies:
     "@elastic/esql-ast": "workspace:^"
+    "@elastic/esql-definitions": "workspace:^"
     "@elastic/esql-grammar": "workspace:^"
     "@elastic/esql-promql-grammar": "workspace:^"
     "@elastic/esql-traversal": "workspace:^"


### PR DESCRIPTION
## Summary

@elastic/esql re-exports these three constants from @elastic/esql-definitions/time, but @elastic/esql-definitions was not listed in its dependencies. In consumers like Kibana that have an older version of @elastic/esql-definitions hoisted at the top level (one that predates the ./time subpath export), TypeScript resolves the re-export against that older copy and silently drops it under skipLibCheck: true, resulting in TS2305: Module '"@elastic/esql"' has no exported member 'DATE_PERIOD_UNITS' at every use site.

The fix is a one-line package.json change: add @elastic/esql-definitions as an explicit dependency. npm/yarn will then install the correct version in @elastic/esql's own node_modules/ rather than falling back to whatever the consumer has hoisted. Runtime was never affected — the bundle inlines the Set values — only types were broken.
## Details

Technical details, breaking changes or considerations you have made while working in this PR.

### Checklist

- [x] A changeset has been added (`yarn changeset`) if this change should be released. See [docs/RELEASE.md](../docs/RELEASE.md).
- [x] The PR is opened as a draft until CI is green.
