### PR TITLE
Fix: Mark the left-hand tuple of a multi-column IN  as incomplete while its subquery is missing

### DIFF
--- a/.changeset/slimy-kids-pump.md
+++ b/.changeset/slimy-kids-pump.md
@@ -1,0 +1,5 @@
+---
+'@elastic/esql': patch
+---
+
+Mark the left-hand tuple of a multi-column `IN` as incomplete while its subquery is missing.

--- a/packages/esql/src/parser/__tests__/function.test.ts
+++ b/packages/esql/src/parser/__tests__/function.test.ts
@@ -506,6 +506,32 @@ describe('function AST nodes', () => {
         });
       });
 
+      it.each([
+        { query: 'FROM a | WHERE (agent,', columnNames: ['agent'] },
+        {
+          query: 'FROM a | WHERE (agent, bytes)',
+          columnNames: ['agent', 'bytes'],
+        },
+      ])('preserves an incomplete multi-column IN left side: $query', ({ query, columnNames }) => {
+        const { root, errors, tokens } = parse(query);
+
+        expect(errors.length).toBeGreaterThan(0);
+        expect(tokens.length).toBeGreaterThan(0);
+        expect(root.commands).toHaveLength(2);
+        expect(root.commands[1]).toMatchObject({
+          type: 'command',
+          name: 'where',
+          args: [
+            {
+              type: 'list',
+              subtype: 'tuple',
+              incomplete: true,
+              values: columnNames.map((name) => ({ type: 'column', name })),
+            },
+          ],
+        });
+      });
+
       it('correctly parses location', () => {
         const src = 'FROM a | STATS a /* asdf */ IN /* 1 */ (1, /* 2 */ 2, /* 3 */ 3 /* 4 */ )';
         const { root } = parse(src);

--- a/packages/esql/src/parser/core/cst_to_ast_converter.ts
+++ b/packages/esql/src/parser/core/cst_to_ast_converter.ts
@@ -2882,7 +2882,14 @@ export class CstToAstConverter {
     ctx: cst.LogicalInMultiColumnSubqueryContext
   ): ast.ESQLAstExpression {
     const left = this.toTuple(ctx.valueExpression_list(), ctx.LP(), ctx.RP());
-    const right = this.fromSubquery(ctx.subquery());
+    const subquery = ctx.subquery();
+
+    if (!subquery) {
+      left.incomplete = true;
+      return left;
+    }
+
+    const right = this.fromSubquery(subquery);
 
     return this.toLogicalInFunction(ctx, left, right, ctx.stop?.stop ?? right.location.max);
   }


### PR DESCRIPTION
## Summary

Mark the left-hand tuple of a multi-column IN  as incomplete while its subquery is missing