### PR TITLE
Rejects deep queries nesting

### DIFF
--- a/.changeset/tidy-parsers-rest.md
+++ b/.changeset/tidy-parsers-rest.md
@@ -1,0 +1,5 @@
+---
+'@elastic/esql': patch
+---
+
+Update ES|QL parser handling of deeply nested query structures

--- a/packages/esql/src/parser/__tests__/query_nesting.test.ts
+++ b/packages/esql/src/parser/__tests__/query_nesting.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Parser } from '..';
+import {
+  assertQueryNesting,
+  MAX_QUERY_NESTING_DEPTH,
+  QUERY_NESTING_ERROR_CODE,
+} from '../core/query_nesting';
+
+const buildNestedStructure = (depth: number): string =>
+  `${'('.repeat(depth)}true${')'.repeat(depth)}`;
+
+const getTokens = (source: string) => {
+  const parser = Parser.create(source);
+  parser.tokens.fill();
+  return parser.tokens.tokens;
+};
+
+describe('query nesting', () => {
+  it('allows supported nesting', () => {
+    const tokens = getTokens(`ROW result = ${buildNestedStructure(MAX_QUERY_NESTING_DEPTH)}`);
+
+    expect(() => assertQueryNesting(tokens)).not.toThrow();
+  });
+
+  it('returns a structured error for unsupported nesting', () => {
+    const result = Parser.parse(
+      `ROW result = ${buildNestedStructure(MAX_QUERY_NESTING_DEPTH + 1)}`
+    );
+
+    expect(result.root.commands).toHaveLength(0);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        code: QUERY_NESTING_ERROR_CODE,
+        message: 'ES|QL statement contains unsupported query nesting',
+      }),
+    ]);
+  });
+
+  it('reports unsupported nesting through parseErrors', () => {
+    const errors = Parser.parseErrors(
+      `ROW result = ${buildNestedStructure(MAX_QUERY_NESTING_DEPTH + 1)}`
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        code: QUERY_NESTING_ERROR_CODE,
+      }),
+    ]);
+  });
+
+  it('does not count non-code tokens toward nesting', () => {
+    const nestedSyntax = '('.repeat(MAX_QUERY_NESTING_DEPTH + 1);
+    const { errors } = Parser.parse(
+      `ROW result = "${nestedSyntax}", \`field${nestedSyntax}\` /* ${nestedSyntax} */`
+    );
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/esql/src/parser/core/parser.ts
+++ b/packages/esql/src/parser/core/parser.ts
@@ -32,6 +32,7 @@ import type {
 import { singleItems } from '../../ast/visitor/utils';
 import { DEFAULT_CHANNEL, SOURCE_COMMANDS } from './constants';
 import type { EsqlParsingTarget } from './types';
+import { assertQueryNesting, QUERY_NESTING_ERROR_CODE, QueryNestingError } from './query_nesting';
 
 export interface ParseOptions {
   /**
@@ -80,6 +81,16 @@ export interface ParseResult<T extends ESQLProperNode = ESQLAstQueryExpression> 
    */
   errors: EditorError[];
 }
+
+const createUnlocatedError = (message: string, code: string): EditorError => ({
+  startLineNumber: 0,
+  endLineNumber: 0,
+  startColumn: 0,
+  endColumn: 0,
+  message,
+  severity: 'error',
+  code,
+});
 
 export class Parser {
   public static readonly create = (src: string, options?: ParseOptions) => {
@@ -371,10 +382,16 @@ export class Parser {
     parser.addErrorListener(this.errors);
   }
 
+  private assertQueryNesting(): void {
+    this.tokens.fill();
+    assertQueryNesting(this.tokens.tokens);
+  }
+
   public parseTarget<T extends ESQLProperNode>([
     rule,
     conversion,
   ]: EsqlParsingTarget): ParseResult<T> {
+    this.assertQueryNesting();
     const ctx = (this.parser[rule]! as Function).call(this.parser);
     const converter = new CstToAstConverter(this);
     const root = (converter[conversion] as Function).call(converter, ctx) as T;
@@ -415,20 +432,16 @@ export class Parser {
       return this.parseTarget<ESQLAstQueryExpression>(['statements', 'fromStatements']);
     } catch (error) {
       const root = Builder.expression.query();
+      const queryNestingError = error instanceof QueryNestingError;
 
       return {
         root,
         ast: root.commands,
         errors: [
-          {
-            startLineNumber: 0,
-            endLineNumber: 0,
-            startColumn: 0,
-            endColumn: 0,
-            message: `Invalid query [${this.src}]`,
-            severity: 'error',
-            code: 'parseError',
-          },
+          createUnlocatedError(
+            queryNestingError ? error.message : `Invalid query [${this.src}]`,
+            queryNestingError ? QUERY_NESTING_ERROR_CODE : 'parseError'
+          ),
         ],
         tokens: [],
       };
@@ -436,7 +449,16 @@ export class Parser {
   }
 
   public parseErrors(): EditorError[] {
-    this.parser.statements();
+    try {
+      this.assertQueryNesting();
+      this.parser.statements();
+    } catch (error) {
+      if (error instanceof QueryNestingError) {
+        return [createUnlocatedError(error.message, QUERY_NESTING_ERROR_CODE)];
+      }
+
+      throw error;
+    }
 
     return this.errors.getErrors();
   }

--- a/packages/esql/src/parser/core/query_nesting.ts
+++ b/packages/esql/src/parser/core/query_nesting.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Token } from 'antlr4';
+import { EsqlLexer as ESQLLexer } from '@elastic/esql-grammar';
+import { DEFAULT_CHANNEL } from './constants';
+
+// Supported boundary for nested query structures.
+export const MAX_QUERY_NESTING_DEPTH = 50;
+export const QUERY_NESTING_ERROR_CODE = 'queryTooComplex';
+
+/** Signals that an ES|QL query contains unsupported nesting. */
+export class QueryNestingError extends Error {
+  constructor() {
+    super('ES|QL statement contains unsupported query nesting');
+    this.name = 'QueryNestingError';
+  }
+}
+
+export const assertQueryNesting = (tokens: readonly Token[]): void => {
+  let nestingDepth = 0;
+
+  for (const token of tokens) {
+    if (token.channel !== DEFAULT_CHANNEL) {
+      continue;
+    }
+
+    switch (token.type) {
+      case ESQLLexer.LP:
+        nestingDepth++;
+        break;
+      case ESQLLexer.RP:
+        nestingDepth = Math.max(0, nestingDepth - 1);
+        break;
+    }
+
+    if (nestingDepth > MAX_QUERY_NESTING_DEPTH) {
+      throw new QueryNestingError();
+    }
+  }
+};


### PR DESCRIPTION
## Summary

Friday task before before relaxing in the SPA

Same as Kibana, more or less

- Applies to all esql-js consumers, and routes.
- The check runs before the expensive parser. (token stream level)
- No false positives from parentheses inside strings, comments, or backticks.
- We do not count [], because ES|QL does not support nested arrays.

ES do something similar before parsing , but it also checks expression-depth limit while building the AST (slow for us, Their Java runtime is different  and their parser does not run synchronously on a single event-loop thread)
